### PR TITLE
Add compression middleware

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -3,6 +3,7 @@ var _ = require('underscore');
 var express = require('express');
 var expressWs = require('express-ws');
 var bodyParser = require('body-parser');
+var compression = require('compression');
 var jobs = require('./job-handlers');
 var paths = require('./path-handlers');
 var prepares = require('./prepare-handlers');
@@ -33,6 +34,7 @@ function add_routes(app, options) {
     let max_saved_messages = 1024;
     let delayed_job_cleanup = 10000;
     let delayed_endpoint_close = options.delayed_endpoint_close || 10000;
+    let compress_response = true;
 
     if (_.has(options.config, 'juttled')) {
         if (_.has(options.config.juttled, 'max_saved_messages')) {
@@ -46,6 +48,10 @@ function add_routes(app, options) {
         if (_.has(options.config.juttled, 'delayed_endpoint_close')) {
             delayed_endpoint_close = options.config.juttled.delayed_endpoint_close;
         }
+
+        if (_.has(options.config.juttled, 'compress_response')) {
+            compress_response = options.config.juttled.compress_response;
+        }
     }
 
     jobs.init({max_saved_messages: max_saved_messages,
@@ -58,6 +64,10 @@ function add_routes(app, options) {
     // Create an express router to handle all the non-websocket
     // routes.
     let router = express.Router();
+
+    if (compress_response) {
+        router.use(compression());
+    }
 
     router.get('/jobs',
                jobs.list_all_jobs);

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -102,4 +102,3 @@ function add_routes(app, options) {
 }
 
 module.exports = add_routes;
-

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "CBuffer": "^1.1.1",
     "bluebird": "^3.2.1",
     "body-parser": "^1.14.2",
+    "compression": "^1.6.1",
     "daemon": "^1.1.0",
     "double-ended-queue": "^0.9.7",
     "express": "^4.13.4",


### PR DESCRIPTION
We could add this to all the routes but POST /jobs gets the most benefit when used with `{ wait: true }`.

I tried running the following request with `{ wait: true }`

```
{
    "bundle": {
      "program": "emit -limit 1000 -from :0: | put name = 'hello world', value = 1000"
    },
  "wait": true
}
```

and the size went from 100k uncompressed to 3k compressed.

@mstemm, @demmer , thoughts/concerns?