### PR TITLE
refactor service to make it embeddable

### DIFF
--- a/bin/juttle-service
+++ b/bin/juttle-service
@@ -2,7 +2,6 @@
 
 /* eslint no-console: 0 */
 var _ = require('underscore');
-var logSetup = require('../lib/log-setup');
 var minimist = require('minimist');
 var daemonize = require('daemon');
 var service = require('../lib/juttle-service');
@@ -64,7 +63,8 @@ if (extra.length > 0) {
     usage();
 }
 
-logSetup.init(opts);
+service.logSetup(_.defaults(opts, {'log-default-output': '/var/log/juttle-service.log'}));
+
 if (opts.daemonize) {
     daemonize();
 }

--- a/bin/juttle-service
+++ b/bin/juttle-service
@@ -4,8 +4,8 @@
 var _ = require('underscore');
 var logSetup = require('../lib/log-setup');
 var minimist = require('minimist');
-var JuttleService = require('../lib/juttle-service');
 var daemonize = require('daemon');
+var service = require('../lib/juttle-service');
 
 var defaults = {
     'port': 2000,
@@ -69,7 +69,7 @@ if (opts.daemonize) {
     daemonize();
 }
 
-require('log4js').getLogger('demo').debug('initializing');
+require('log4js').getLogger('juttle-service').debug('initializing');
 
 var service_opts = {port: opts.port, root_directory: opts.root};
 
@@ -77,4 +77,4 @@ if (_.has(opts, 'config')) {
     service_opts.config_path = opts['config'];
 }
 
-new JuttleService(service_opts);
+service.run(service_opts);

--- a/lib/juttle-service.js
+++ b/lib/juttle-service.js
@@ -4,17 +4,24 @@ var logger = require('log4js').getLogger('juttle-service');
 
 var read_config = require('juttle/lib/config/read-config');
 var Juttle = require('juttle/lib/runtime').Juttle;
+
+// Exposed handler for registering routes on an express app
 var add_routes = require('./routes');
 
+// Load the juttle configuration from either options.config_path or the
+// default juttle configuration locations.
+function configure(options) {
+    let config = read_config(options);
+
+    // Add the config as an option so add_routes doesn't have to read it again.
+    options.config = config;
+    Juttle.adapters.configure(config.adapters);
+}
+
+// Simple wrapper class around a running instance of the service.
 class JuttleService {
-
     constructor(options) {
-
-        let config = read_config(options);
-
-        // Add the config as an option so add_routes doesn't have to read it again.
-        options.config = config;
-        Juttle.adapters.configure(config.adapters);
+        configure(options);
 
         this._app = express();
 
@@ -30,7 +37,15 @@ class JuttleService {
     stop() {
         this._server.close();
     }
-
 }
 
-module.exports = JuttleService;
+// Hook to run a new instance of the service
+function run(options) {
+    return new JuttleService(options);
+}
+
+module.exports = {
+    configure,
+    add_routes,
+    run
+};

--- a/lib/juttle-service.js
+++ b/lib/juttle-service.js
@@ -2,6 +2,7 @@
 var express = require('express');
 var logger = require('log4js').getLogger('juttle-service');
 
+var logSetup = require('./log-setup');
 var read_config = require('juttle/lib/config/read-config');
 var Juttle = require('juttle/lib/runtime').Juttle;
 
@@ -47,5 +48,6 @@ function run(options) {
 module.exports = {
     configure,
     addRoutes,
+    logSetup,
     run
 };

--- a/lib/juttle-service.js
+++ b/lib/juttle-service.js
@@ -6,14 +6,14 @@ var read_config = require('juttle/lib/config/read-config');
 var Juttle = require('juttle/lib/runtime').Juttle;
 
 // Exposed handler for registering routes on an express app
-var add_routes = require('./routes');
+var addRoutes = require('./routes');
 
 // Load the juttle configuration from either options.config_path or the
 // default juttle configuration locations.
 function configure(options) {
     let config = read_config(options);
 
-    // Add the config as an option so add_routes doesn't have to read it again.
+    // Add the config as an option so addRoutes doesn't have to read it again.
     options.config = config;
     Juttle.adapters.configure(config.adapters);
 }
@@ -27,7 +27,7 @@ class JuttleService {
 
         this._app.disable('x-powered-by');
 
-        add_routes(this._app, options);
+        addRoutes(this._app, options);
 
         this._server = this._app.listen(options.port, () => {
             logger.info('Juttle service listening at http://localhost:' + options.port + ' with root directory:' + options.root_directory);
@@ -46,6 +46,6 @@ function run(options) {
 
 module.exports = {
     configure,
-    add_routes,
+    addRoutes,
     run
 };

--- a/lib/log-setup.js
+++ b/lib/log-setup.js
@@ -2,7 +2,7 @@ var _ = require('underscore');
 var fs = require('fs-extra');
 var log4js = require('log4js');
 
-module.exports.init = function(opts) {
+function logSetup(opts) {
     if (opts['log-config']) {
         log4js.configure(opts['log-config']);
     } else {
@@ -15,7 +15,7 @@ module.exports.init = function(opts) {
         // If daemonizing and if no output file was specified, use a
         // default.
         if (opts.daemonize && !_.has(opts, 'output')) {
-            opts.output = '/var/log/juttle-service.log';
+            opts.output = opts['log-default-output'];
         }
 
         if (_.has(opts, 'output')) {
@@ -43,3 +43,5 @@ module.exports.init = function(opts) {
         log4js.configure(log4js_opts);
     }
 }
+
+module.exports = logSetup;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "juttle-service",
   "version": "0.1.0",
   "description": "API-based execution engine for juttle programs",
-  "main": "bin/juttle-service",
+  "main": "lib/juttle-service",
   "bin": {
     "juttle-service": "bin/juttle-service",
     "juttle-service-client": "bin/juttle-service-client"

--- a/test/juttle-service.spec.js
+++ b/test/juttle-service.spec.js
@@ -13,7 +13,7 @@ var JSDP = require('juttle-jsdp');
 var moment = require('moment');
 
 var juttleRoot = __dirname + '/juttle-root';
-logSetup.init({'log-level': process.env.DEBUG ? 'debug' : 'info'});
+logSetup({'log-level': process.env.DEBUG ? 'debug' : 'info'});
 
 var juttleBaseUrl;
 var juttleHostPort;

--- a/test/juttle-service.spec.js
+++ b/test/juttle-service.spec.js
@@ -2,7 +2,7 @@ var _ = require('underscore');
 var chakram = require('chakram');
 var expect = chakram.expect;
 var logSetup = require('../lib/log-setup');
-var JuttleService = require('../lib/juttle-service');
+var service = require('../lib/juttle-service');
 var WebSocket = require('ws');
 var Promise = require('bluebird');
 var findFreePort = Promise.promisify(require('find-free-port'));
@@ -96,7 +96,7 @@ describe('Juttle Service Tests', function() {
         .then((freePort) => {
             juttleHostPort = 'http://localhost:' + freePort;
             juttleBaseUrl = juttleHostPort + '/api/v0';
-            juttled = new JuttleService({port: freePort, root_directory: juttleRoot, delayed_endpoint_close: 2000});
+            juttled = service.run({port: freePort, root_directory: juttleRoot, delayed_endpoint_close: 2000});
         });
     });
 


### PR DESCRIPTION
Rework the juttle-service module so that instead of exporting a class, it exports a simple closure with methods to both run/stop the service itself as well as adding the routes and setting up logging.

This will enable the juttle-engine to more easily embed the service without needing to repeat as much code.
