### PR TITLE
POST jobs: change response format when wait is set to true

### DIFF
--- a/docs/jobs-api.md
+++ b/docs/jobs-api.md
@@ -130,7 +130,7 @@ POST /api/v0/jobs HTTP/1.1
     "output": {
         "sink0": {
             "data": [{type: 'mark', 'time:date': '1970-01-01T00:00:00.000Z'},
-                     {"type": "point", "point": {"foo": "bar", "time:date": "1970-01-01T00:00:00.000Z"}}],
+                     {"type": "points", "points": [{"foo": "bar", "time:date": "1970-01-01T00:00:00.000Z"}]}],
             "options": {
                 "title": "My Table"
             },

--- a/lib/immediate-juttle-job.js
+++ b/lib/immediate-juttle-job.js
@@ -47,15 +47,19 @@ var ImmediateJuttleJob = JuttleJob.extend({
             // Append the data to the appropriate sink's array of data.
             self._program_output[msg.sink_id].data.push(data);
         } else if (msg.type === 'points') {
-            var new_points = _.map(msg.points, function(point) {
-                return {
-                    type: 'point',
-                    point: point
-                };
-            });
-
-            self._program_output[msg.sink_id].data =
-                self._program_output[msg.sink_id].data.concat(new_points);
+            var currentData = self._program_output[msg.sink_id].data;
+            var lastData = _.last(currentData);
+            // If the most recently buffered data is not a points entry, create one.
+            // Otherwise, concat the new points into the last entry.
+            if (_.isEmpty(currentData) || lastData.type !== 'points') {
+                currentData.push({
+                    type: 'points',
+                    points: msg.points
+                });
+            }
+            else {
+                lastData.points = lastData.points.concat(msg.points);
+            }
         }
     },
 

--- a/test/juttle-service.spec.js
+++ b/test/juttle-service.spec.js
@@ -780,7 +780,7 @@ describe('Juttle Service Tests', function() {
                     warnings: [],
                     output: {
                         view0: {
-                            data: [{type: 'point', point: {foo: 'bar', 'time:date': '1970-01-01T00:00:00.000Z'}}],
+                            data: [{type: 'points', points: [{foo: 'bar', 'time:date': '1970-01-01T00:00:00.000Z'}]}],
                             options: {
                                 _jut_time_bounds: []
                             },
@@ -843,10 +843,9 @@ describe('Juttle Service Tests', function() {
                     output: {
                         view0: {
                             data: [{type: 'mark', 'time:date': '1970-01-01T00:00:00.000Z'},
-                                   {type: 'point', point: {'time:date': '1970-01-01T00:00:00.000Z'}},
-                                   {type: 'point', point: {'time:date': '1970-01-01T00:00:01.000Z'}},
+                                   {type: 'points', points: [{'time:date': '1970-01-01T00:00:00.000Z'}, {'time:date': '1970-01-01T00:00:01.000Z'}]},
                                    {type: 'mark', 'time:date': '1970-01-01T00:00:02.000Z'},
-                                   {type: 'point', point: {'time:date': '1970-01-01T00:00:02.000Z'}},
+                                   {type: 'points', points: [{'time:date': '1970-01-01T00:00:02.000Z'}]},
                                    {type: 'mark', 'time:date': '1970-01-01T00:00:04.000Z'}],
                             options: {
                                 _jut_time_bounds: [],
@@ -856,10 +855,9 @@ describe('Juttle Service Tests', function() {
                         },
                         view1: {
                             data: [{type: 'mark', 'time:date': '1970-01-01T00:00:00.000Z'},
-                                   {type: 'point', point: {'time:date': '1970-01-01T00:00:00.000Z'}},
-                                   {type: 'point', point: {'time:date': '1970-01-01T00:00:01.000Z'}},
+                                   {type: 'points', points: [{'time:date': '1970-01-01T00:00:00.000Z'}, {'time:date': '1970-01-01T00:00:01.000Z'}]},
                                    {type: 'mark', 'time:date': '1970-01-01T00:00:02.000Z'},
-                                   {type: 'point', point: {'time:date': '1970-01-01T00:00:02.000Z'}},
+                                   {type: 'points', points: [{'time:date': '1970-01-01T00:00:02.000Z'}]},
                                    {type: 'mark', 'time:date': '1970-01-01T00:00:04.000Z'}],
                             options: {
                                 _jut_time_bounds: [],
@@ -881,7 +879,7 @@ describe('Juttle Service Tests', function() {
                     warnings: [],
                     output: {
                         view0: {
-                            data: [{type: 'point', point: {foo: 'bar', 'time:date': '1970-01-01T00:00:00.000Z'}}],
+                            data: [{type: 'points', points: [{foo: 'bar', 'time:date': '1970-01-01T00:00:00.000Z'}]}],
                             options: {
                                 _jut_time_bounds: []
                             },
@@ -909,7 +907,7 @@ describe('Juttle Service Tests', function() {
                     warnings: [],
                     output: {
                         view0: {
-                            data: [{type: 'point', point: {foo: 'baz', 'time:date': '1970-01-01T00:00:00.000Z'}}],
+                            data: [{type: 'points', points: [{foo: 'baz', 'time:date': '1970-01-01T00:00:00.000Z'}]}],
                             options: {
                                 _jut_time_bounds: []
                             },
@@ -974,7 +972,7 @@ describe('Juttle Service Tests', function() {
                     }],
                     output: {
                         view0: {
-                            data: [{type: 'point', point: {}}],
+                            data: [{type: 'points', points: [{}]}],
                             options: {
                                 _jut_time_bounds: []
                             },


### PR DESCRIPTION
Instead of putting each point into its own object in the `data` array, batch them up where possible.

The reasoning for this is twofold:
- decrease the size of the response
- make the response more in-line with type of messages we send over the [websocket](https://github.com/juttle/juttle-service/blob/master/docs/jsdp-api.md) version of the API

@mstemm @demmer 