### PR TITLE
handle dangling symlinks

### DIFF
--- a/lib/path-handlers.js
+++ b/lib/path-handlers.js
@@ -35,7 +35,6 @@ function get_path(req, res, next) {
 function get_dir(req, res, next) {
     var directories = [], juttles = [], relative_path, abs_path;
 
-
     Promise.try(function() {
         relative_path = req.query.path || '';
         relative_path = relative_path[0] === '/' ? relative_path.substring(1) : relative_path;
@@ -47,6 +46,8 @@ function get_dir(req, res, next) {
         }
 
         abs_path = path.join(root_dir, relative_path);
+
+        logger.debug('get_dir request', req.query.path, 'resolved', abs_path);
 
         if (abs_path.indexOf(root_dir) !== 0) {
             throw errors.directoryAccessError(req.query.path);
@@ -62,6 +63,15 @@ function get_dir(req, res, next) {
                     directories.push(file_path);
                 } else if (path.extname(file_path) === '.juttle'){
                     juttles.push(file_path);
+                }
+            })
+            .catch(function(err) {
+                // Ignore ENOENT errors -- this can happen if the directory
+                // contains a dangling symlink
+                if (err.code === 'ENOENT') {
+                    return;
+                } else {
+                    throw err;
                 }
             })
         });

--- a/test/juttle-root/dangling-link.juttle
+++ b/test/juttle-root/dangling-link.juttle
@@ -1,0 +1,1 @@
+does-not-exist.juttle


### PR DESCRIPTION
Fix the path handlers to ignore dangling symlinks.

If a directory contains a dangling symlink, the directory entry will
exist but when we call stat on the file, it will return ENOENT.

Catch these cases and simply ignore the offending file.

To test that this works, add a dangling symlink to the juttle-root
directory. While there isn't an actual test for this specific
functionality, without the check in the code, the other positive
test cases fail in the presence of this file.

Fixes #25 