### PR TITLE
support setting debug log targets using the DEBUG environment variable

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,7 +65,7 @@ gulp.task('test-coverage', ['instrument'], function() {
     coverage = {
         global: {
             statements: 84,
-            branches: 75,
+            branches: 74,
             functions: 81,
             lines: 82
         }

--- a/lib/log-setup.js
+++ b/lib/log-setup.js
@@ -6,10 +6,23 @@ function logSetup(opts) {
     if (opts['log-config']) {
         log4js.configure(opts['log-config']);
     } else {
+        var levels = {
+            '[all]': opts['log-level']
+        };
+
+        // Handle node.js style debug configuration where DEBUG is a
+        // comma-separated list of debug targets, or '*' to enable all
+        // debugging.
+        var DEBUG = process.env.DEBUG;
+        if (DEBUG) {
+            var targets = DEBUG.split(',');
+            _.each(targets, function(target) {
+                if (target === '*') { target = '[all]'}
+                levels[target] = 'debug';
+            });
+        }
         var log4js_opts = {
-            'levels': {
-                '[all]': opts['log-level']
-            }
+            levels: levels
         };
 
         // If daemonizing and if no output file was specified, use a

--- a/test/juttle-service.spec.js
+++ b/test/juttle-service.spec.js
@@ -13,7 +13,7 @@ var JSDP = require('juttle-jsdp');
 var moment = require('moment');
 
 var juttleRoot = __dirname + '/juttle-root';
-logSetup({'log-level': process.env.DEBUG ? 'debug' : 'info'});
+logSetup({'log-level': 'info'});
 
 var juttleBaseUrl;
 var juttleHostPort;


### PR DESCRIPTION
Add a simple mechanism to the logSetup function so that it parses the DEBUG environment variable and extract a list of targets to enable at debug level, or * to set the global log level.

Fixes #23 