### PR TITLE
Expose all exportable stuff through juttle-service.js.

### DIFF
--- a/lib/juttle-service.js
+++ b/lib/juttle-service.js
@@ -5,6 +5,9 @@ var logger = require('log4js').getLogger('juttle-service');
 var logSetup = require('./log-setup');
 var read_config = require('juttle/lib/config/read-config');
 var Juttle = require('juttle/lib/runtime').Juttle;
+var JuttleBundler = require('./bundler');
+var WebsocketEndpoint = require('./websocket-endpoint');
+var JuttleServiceClient = require('./juttle-service-client');
 
 // Exposed handler for registering routes on an express app
 var addRoutes = require('./routes');
@@ -46,8 +49,13 @@ function run(options) {
 }
 
 module.exports = {
-    configure,
-    addRoutes,
-    logSetup,
-    run
+    service: {
+        configure: configure,
+        run: run,
+        addRoutes: addRoutes
+    },
+    logSetup: logSetup,
+    bundler: JuttleBundler,
+    websocketEndpoint: WebsocketEndpoint,
+    client: JuttleServiceClient
 };

--- a/lib/juttle-service.js
+++ b/lib/juttle-service.js
@@ -1,4 +1,5 @@
 'use strict';
+var _ = require('underscore');
 var express = require('express');
 var logger = require('log4js').getLogger('juttle-service');
 
@@ -15,11 +16,14 @@ var addRoutes = require('./routes');
 // Load the juttle configuration from either options.config_path or the
 // default juttle configuration locations.
 function configure(options) {
-    let config = read_config(options);
+    if (! _.has(options, 'config')) {
+        let config = read_config(options);
 
-    // Add the config as an option so addRoutes doesn't have to read it again.
-    options.config = config;
-    Juttle.adapters.configure(config.adapters);
+        // Add the config as an option so addRoutes doesn't have to read it again.
+        options.config = config;
+    }
+
+    Juttle.adapters.configure(options.config.adapters);
 }
 
 // Simple wrapper class around a running instance of the service.

--- a/test/juttle-service-client.spec.js
+++ b/test/juttle-service-client.spec.js
@@ -143,12 +143,39 @@ describe('juttle-service-client tests', function() {
         }, {interval: 100, max_tries: 10});
     });
 
+    it('Can run a job with --wait', function() {
+        let opts = {path: 'simple.juttle', 'wait': true};
+        JuttleService.client.command(server, opts, 'run');
+        return retry(function() {
+            expect(current_output).to.contain('Starting program and waiting for it to finish');
+            expect(exit_status).to.equal(undefined);
+        }, {interval: 100, max_tries: 10});
+    });
+
+    it('Can run a job with syntax errors and get errors back', function() {
+        let opts = {path: 'has-syntax-error.juttle'};
+        JuttleService.client.command(server, opts, 'run');
+        return retry(function() {
+            expect(current_errors).to.contain('JUTTLE-SYNTAX-ERROR-WITH-EXPECTED');
+            expect(exit_status).to.equal(undefined);
+        }, {interval: 100, max_tries: 10});
+    });
+
     it('Can get_inputs', function() {
         let opts = {path: 'inputs.juttle', input: 'inval=my'};
         JuttleService.client.command(server, opts, 'get_inputs');
         return retry(function() {
             expect(current_output).to.contain('"value": "my"');
             expect(exit_status).to.equal(undefined);
+        }, {interval: 100, max_tries: 10});
+    });
+
+    it('Can get_inputs with errors', function() {
+        let opts = {path: 'inputs.juttle', input: 'inval'};
+        JuttleService.client.command(server, opts, 'get_inputs');
+        return retry(function() {
+            expect(current_errors).to.contain('invalid input inval');
+            expect(exit_status).to.equal(1);
         }, {interval: 100, max_tries: 10});
     });
 

--- a/test/juttle-service.spec.js
+++ b/test/juttle-service.spec.js
@@ -96,7 +96,21 @@ describe('Juttle Service Tests', function() {
         .then((freePort) => {
             juttleHostPort = 'http://localhost:' + freePort;
             juttleBaseUrl = juttleHostPort + '/api/v0';
-            juttle_service = JuttleService.service.run({port: freePort, root_directory: juttleRoot, delayed_endpoint_close: 2000});
+
+            // Set all of the config values for the service directly
+            // just so we get increased code coverage in routes.js
+            juttle_service = JuttleService.service.run({
+                port: freePort,
+                root_directory: juttleRoot,
+                config: {
+                    'juttle-service': {
+                        delayed_endpoint_close: 2000,
+                        max_saved_messages: 1000,
+                        delayed_job_cleanup: 10000,
+                        compress_response: false
+                    }
+                }
+            });
         });
     });
 

--- a/test/juttle-service.spec.js
+++ b/test/juttle-service.spec.js
@@ -2,7 +2,7 @@ var _ = require('underscore');
 var chakram = require('chakram');
 var expect = chakram.expect;
 var logSetup = require('../lib/log-setup');
-var service = require('../lib/juttle-service');
+var JuttleService = require('../lib/juttle-service');
 var WebSocket = require('ws');
 var Promise = require('bluebird');
 var findFreePort = Promise.promisify(require('find-free-port'));
@@ -96,7 +96,7 @@ describe('Juttle Service Tests', function() {
         .then((freePort) => {
             juttleHostPort = 'http://localhost:' + freePort;
             juttleBaseUrl = juttleHostPort + '/api/v0';
-            juttle_service = service.run({port: freePort, root_directory: juttleRoot, delayed_endpoint_close: 2000});
+            juttle_service = JuttleService.service.run({port: freePort, root_directory: juttleRoot, delayed_endpoint_close: 2000});
         });
     });
 


### PR DESCRIPTION
Feedback from Oleg on PR juttle/juttle-engine#19. Instead of cherrry
picking individual modules from juttle-service for use in
juttle-engine, expose any needed modules through juttle-service.js.

That way there's one require() for anyone using juttle-service
modules, and juttle-service developers can know that anything required
in juttle-service.js are semi-public and can't be changed without
being aware of compatibility.

@go-oleg 