### PR TITLE
Add cors headers to all requests

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -4,6 +4,7 @@ var express = require('express');
 var expressWs = require('express-ws');
 var bodyParser = require('body-parser');
 var compression = require('compression');
+var cors = require('cors');
 var jobs = require('./job-handlers');
 var paths = require('./path-handlers');
 var prepares = require('./prepare-handlers');
@@ -72,6 +73,9 @@ function add_routes(app, options) {
     if (compress_response) {
         router.use(compression());
     }
+
+    // allow requests from all browser origins
+    router.use(cors());
 
     router.get('/jobs',
                jobs.list_all_jobs);

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "bluebird": "^3.2.1",
     "body-parser": "^1.14.2",
     "compression": "^1.6.1",
+    "cors": "^2.7.1",
     "daemon": "^1.1.0",
     "double-ended-queue": "^0.9.7",
     "express": "^4.13.4",

--- a/test/juttle-service.spec.js
+++ b/test/juttle-service.spec.js
@@ -1794,4 +1794,12 @@ describe('Juttle Service Tests', function() {
             });
         });
     });
+
+    describe('cors', function() {
+        it('responses return cors header allow all origins', function() {
+            var response = chakram.get(juttleBaseUrl + '/directory')
+            expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+            return chakram.wait();
+        })
+    });
 });


### PR DESCRIPTION
Primarily these came out of development hassles and trying to run
juttle-viewer/juttle-client-library (from a different port) against
juttle-service. Ultimately, I think (at least by default) juttle-service
should allow requests from all browser clients.

@mstemm @demmer  alright with you guys?