### PR TITLE
module: create an explicit package module

### DIFF
--- a/bin/juttle-service
+++ b/bin/juttle-service
@@ -4,7 +4,8 @@
 var _ = require('underscore');
 var minimist = require('minimist');
 var daemonize = require('daemon');
-var service = require('../lib/juttle-service');
+var service = require('..').service;
+var logSetup = require('..').logSetup;
 
 var defaults = {
     'port': 2000,
@@ -63,7 +64,7 @@ if (extra.length > 0) {
     usage();
 }
 
-service.logSetup(_.defaults(opts, {'log-default-output': '/var/log/juttle-service.log'}));
+logSetup(_.defaults(opts, {'log-default-output': '/var/log/juttle-service.log'}));
 
 if (opts.daemonize) {
     daemonize();

--- a/bin/juttle-service-client
+++ b/bin/juttle-service-client
@@ -3,7 +3,7 @@
 /* eslint no-console: 0 */
 var _ = require('underscore');
 var minimist = require('minimist');
-var JuttleServiceClient = require('../lib/juttle-service-client');
+var client = require('..').client;
 
 var defaults = {
     'juttle-service': 'localhost:2000',
@@ -17,9 +17,9 @@ _.defaults(opts, defaults);
 
 if (opts.help ||
     opts._.length !== 1) {
-    JuttleServiceClient.usage();
+    client.usage();
 }
 
 var command = opts._[0];
 
-JuttleServiceClient.command(opts['juttle-service'], opts, command);
+client.command(opts['juttle-service'], opts, command);

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+module.exports = {
+    service: require('./lib/juttle-service'),
+    logSetup: require('./lib/log-setup'),
+    JuttleBundler: require('./lib/bundler'),
+    WebsocketEndpoint: require('./lib/websocket-endpoint'),
+    client: require('./lib/juttle-service-client')
+};

--- a/lib/juttle-service.js
+++ b/lib/juttle-service.js
@@ -2,13 +2,8 @@
 var _ = require('underscore');
 var express = require('express');
 var logger = require('log4js').getLogger('juttle-service');
-
-var logSetup = require('./log-setup');
 var read_config = require('juttle/lib/config/read-config');
 var Juttle = require('juttle/lib/runtime').Juttle;
-var JuttleBundler = require('./bundler');
-var WebsocketEndpoint = require('./websocket-endpoint');
-var JuttleServiceClient = require('./juttle-service-client');
 
 // Exposed handler for registering routes on an express app
 var addRoutes = require('./routes');
@@ -53,13 +48,7 @@ function run(options) {
 }
 
 module.exports = {
-    service: {
-        configure: configure,
-        run: run,
-        addRoutes: addRoutes
-    },
-    logSetup: logSetup,
-    bundler: JuttleBundler,
-    websocketEndpoint: WebsocketEndpoint,
-    client: JuttleServiceClient
+    configure: configure,
+    run: run,
+    addRoutes: addRoutes
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "juttle-service",
   "version": "0.1.0",
   "description": "API-based execution engine for juttle programs",
-  "main": "lib/juttle-service",
+  "main": "index",
   "bin": {
     "juttle-service": "bin/juttle-service",
     "juttle-service-client": "bin/juttle-service-client"

--- a/test/juttle-service.spec.js
+++ b/test/juttle-service.spec.js
@@ -2,7 +2,7 @@ var _ = require('underscore');
 var chakram = require('chakram');
 var expect = chakram.expect;
 var logSetup = require('../lib/log-setup');
-var JuttleService = require('../lib/juttle-service');
+var service = require('../lib/juttle-service');
 var WebSocket = require('ws');
 var Promise = require('bluebird');
 var findFreePort = Promise.promisify(require('find-free-port'));
@@ -99,7 +99,7 @@ describe('Juttle Service Tests', function() {
 
             // Set all of the config values for the service directly
             // just so we get increased code coverage in routes.js
-            juttle_service = JuttleService.service.run({
+            juttle_service = service.run({
                 port: freePort,
                 root_directory: juttleRoot,
                 config: {


### PR DESCRIPTION
Instead of attaching all the exports to the juttle-service module
itself, create an explicit index.js as the top-level export of the
package.