### PR TITLE
log-setup: change default behavior to log at info level

### DIFF
--- a/lib/log-setup.js
+++ b/lib/log-setup.js
@@ -3,11 +3,12 @@ var fs = require('fs-extra');
 var log4js = require('log4js');
 
 function logSetup(opts) {
+    opts = opts || {};
     if (opts['log-config']) {
         log4js.configure(opts['log-config']);
     } else {
         var levels = {
-            '[all]': opts['log-level']
+            '[all]': opts['log-level'] || 'info'
         };
 
         // Handle node.js style debug configuration where DEBUG is a


### PR DESCRIPTION
If logSetup is called with no options or with an undefined log-level,
set the default logging level to info.