### PR TITLE
index: export the log4js.getLogger

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,14 @@
+//
+// In order for the exported logSetup utility function to actually take effect,
+// we need to export the getLogger function from the same log4js module that was
+// configured by logSetup, so export it here.
+//
+var getLogger = require('log4js').getLogger;
+
 module.exports = {
     service: require('./lib/juttle-service'),
     logSetup: require('./lib/log-setup'),
+    getLogger: getLogger,
     JuttleBundler: require('./lib/bundler'),
     WebsocketEndpoint: require('./lib/websocket-endpoint'),
     client: require('./lib/juttle-service-client')


### PR DESCRIPTION
In order for the logSetup function to actually have an effect, we
need to use the same log4js instance that was configured, so in order
for juttle-engine and other embedding packages to use it, export a
getLogger wrapper.