### PR TITLE
delayed_endpoint_close: honor when websocket connects before job finishes

### DIFF
--- a/lib/ws-juttle-job.js
+++ b/lib/ws-juttle-job.js
@@ -32,8 +32,8 @@ var WebsocketJuttleJob = JuttleJob.extend({
             setTimeout(function() {
                 self._endpoints.forEach(function(endpoint) {
                     endpoint.close();
-                }, self._delayed_endpoint_close);
-            });
+                });
+            }, self._delayed_endpoint_close);
         });
     },
 


### PR DESCRIPTION
`self._delayed_endpoint_close` was hangin out in the call to `forEach` instead of `setTimeout`

@mstemm 