### PR TITLE
ES6: convert to ES6 classes from extendable-base

### DIFF
--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -3,7 +3,6 @@
 /* jshint node:true */
 var _ = require('underscore');
 var path = require('path');
-var Base = require('extendable-base');
 var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require('fs'));
 var compiler = require('juttle/lib/compiler');
@@ -13,8 +12,8 @@ var resolver_utils = require('juttle/lib/module-resolvers/resolver-utils');
 var JuttleServiceErrors = require('./errors');
 var JuttleErrors = require('juttle/lib/errors');
 
-var JuttleBundler = Base.extend({
-    initialize: function(options) {
+class JuttleBundler {
+    constructor(options) {
         var self = this;
 
         self.options = options || {};
@@ -41,9 +40,9 @@ var JuttleBundler = Base.extend({
             self._search_paths.push(self.options.root_dir);
             self._search_filename_dirname = true;
         }
-    },
+    }
 
-    bundle: function(respath) {
+    bundle(respath) {
         var self = this;
 
         var program;
@@ -122,7 +121,7 @@ var JuttleBundler = Base.extend({
                 }
             });
     }
-});
+}
 
 module.exports = JuttleBundler;
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -17,7 +17,7 @@ function messageForCode(code, info) {
 
 
 class BaseError extends Error {
-    constructor(name, code, status, info) {
+    constructor(name, code, info) {
         super();
 
         this.message = messageForCode(code, info);
@@ -29,8 +29,11 @@ class BaseError extends Error {
         }
 
         this.code = code;
-        this.status = status;
         this.info = info;
+    }
+
+    status() {
+        return 500;
     }
 }
 
@@ -41,7 +44,7 @@ var errors = {};
 // more specific error can not be found.
 class UnknownError extends BaseError {
     constructor(info) {
-        super('UnknownError', 'JS-UNKNOWN-ERROR', 500, info);
+        super('UnknownError', 'JS-UNKNOWN-ERROR', info);
     }
 }
 
@@ -54,55 +57,91 @@ class UnknownError extends BaseError {
 
 class JuttleError extends BaseError {
     constructor(info) {
-        super('JuttleError', 'JS-JUTTLE-ERROR', 400, info);
+        super('JuttleError', 'JS-JUTTLE-ERROR', info);
+    }
+
+    status() {
+        return 400;
     }
 }
 
 class BundleError extends BaseError {
     constructor(info) {
-        super('BundleError', 'JS-BUNDLE-ERROR', 400, info);
+        super('BundleError', 'JS-BUNDLE-ERROR', info);
+    }
+
+    status() {
+        return 400;
     }
 }
 
 class JobNotFoundError extends BaseError {
     constructor(info) {
-        super('JobNotFoundError', 'JS-JOB-NOT-FOUND-ERROR', 404, info);
+        super('JobNotFoundError', 'JS-JOB-NOT-FOUND-ERROR', info);
+    }
+
+    status() {
+        return 404;
     }
 }
 
 class FileNotFoundError extends BaseError {
     constructor(info) {
-        super('FileNotFoundError', 'JS-FILE-NOT-FOUND-ERROR', 404, info);
+        super('FileNotFoundError', 'JS-FILE-NOT-FOUND-ERROR', info);
+    }
+
+    status() {
+        return 404;
     }
 }
 
 class FileAccessError extends BaseError {
     constructor(info) {
-        super('FileAccessError', 'JS-FILE-ACCESS-ERROR', 403, info);
+        super('FileAccessError', 'JS-FILE-ACCESS-ERROR', info);
+    }
+
+    status() {
+        return 403;
     }
 }
 
 class DirectoryNotFoundError extends BaseError {
     constructor(info) {
-        super('DirectoryNotFoundError', 'JS-DIR-NOT-FOUND-ERROR', 404, info);
+        super('DirectoryNotFoundError', 'JS-DIR-NOT-FOUND-ERROR', info);
+    }
+
+    status() {
+        return 404;
     }
 }
 
 class DirectoryAccessError extends BaseError {
     constructor(info) {
-        super('DirectoryAccessError', 'JS-DIR-ACCESS-ERROR', 403, info);
+        super('DirectoryAccessError', 'JS-DIR-ACCESS-ERROR', info);
+    }
+
+    status() {
+        return 403;
     }
 }
 
 class InvalidPathError extends BaseError {
     constructor(info) {
-        super('InvalidPathError', 'JS-INVALID-PATH-ERROR', 400, info);
+        super('InvalidPathError', 'JS-INVALID-PATH-ERROR', info);
+    }
+
+    status() {
+        return 400;
     }
 }
 
 class TimeoutError extends BaseError {
     constructor(info) {
-        super('TimeoutError', 'JS-TIMEOUT-ERROR', 408, info);
+        super('TimeoutError', 'JS-TIMEOUT-ERROR', info);
+    }
+
+    status() {
+        return 408;
     }
 }
 
@@ -147,16 +186,7 @@ errors.timeoutError = function(timeout) {
 };
 
 errors.is_juttle_service_error = function(err) {
-    return (err instanceof UnknownError ||
-            err instanceof JuttleError ||
-            err instanceof BundleError ||
-            err instanceof JobNotFoundError ||
-            err instanceof FileNotFoundError ||
-            err instanceof FileAccessError ||
-            err instanceof DirectoryNotFoundError ||
-            err instanceof DirectoryAccessError ||
-            err instanceof InvalidPathError ||
-            err instanceof TimeoutError);
+    return (err instanceof BaseError);
 };
 
 module.exports = errors;

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -46,7 +46,7 @@ class UnknownError extends BaseError {
 }
 
 
-// All var from the juttle compiler and runtime are grouped as this
+// All errors from the juttle compiler and runtime are grouped as this
 // error. The info.err field contains the complete error object from
 // the Juttle compiler or runtime, and the info.bundle field should
 // contain a program bundle containing the program and modules that

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -2,25 +2,25 @@
 
 // This file defines error classes related to the JuttleService's REST api.
 
-var Base = require('extendable-base');
 var messages = require('./strings/juttle-service-error-strings-en-US').error;
 var _ = require('underscore');
 
 // Similar to version in juttle/lib/errors.js.
+function messageForCode(code, info) {
+    var template = _.template(messages[code], {
+        interpolate: /\{\{([^}]*)\}\}/g,
+        variable: 'info'
+    });
+
+    return template(info);
+}
 
 
-var BaseError = Base.inherits(Error, {
+class BaseError extends Error {
+    constructor(name, code, status, info) {
+        super();
 
-    template: function(info) {
-        var template = _.template(messages[this.code], {
-            interpolate: /\{\{([^}]*)\}\}/g,
-            variable: 'info'
-        });
-
-        return template(info);
-    },
-
-    initialize: function(info) {
+        this.message = messageForCode(code, info);
         Error.call(this, this.message);
 
         // not present on IE
@@ -28,140 +28,135 @@ var BaseError = Base.inherits(Error, {
             Error.captureStackTrace(this, this.constructor);
         }
 
-        // Template the message given the info object
-        this.message = this.template(info);
-
-        // copy the code from the prototype to the instance so it will
-        // be serialized.
-        this.code = this.code;
-
+        this.code = code;
+        this.status = status;
         this.info = info;
     }
-});
+}
 
 var errors = {};
 
 // An error that can not be identified. Ideally, this error should
 // never be thrown. It is only used as a catchall in cases where a
 // more specific error can not be found.
-errors.UnknownError = BaseError.extend({
-    name: 'UnknownError',
-    code: 'JS-UNKNOWN-ERROR',
-    status: 500
-});
+class UnknownError extends BaseError {
+    constructor(info) {
+        super('UnknownError', 'JS-UNKNOWN-ERROR', 500, info);
+    }
+}
 
 
-// All errors from the juttle compiler and runtime are grouped as this
+// All var from the juttle compiler and runtime are grouped as this
 // error. The info.err field contains the complete error object from
 // the Juttle compiler or runtime, and the info.bundle field should
 // contain a program bundle containing the program and modules that
 // resulted in the error.
 
-errors.JuttleError = BaseError.extend({
-    name: 'JuttleError',
-    code: 'JS-JUTTLE-ERROR',
-    status: 400
-});
+class JuttleError extends BaseError {
+    constructor(info) {
+        super('JuttleError', 'JS-JUTTLE-ERROR', 400, info);
+    }
+}
 
-errors.BundleError = BaseError.extend({
-    name: 'BundleError',
-    code: 'JS-BUNDLE-ERROR',
-    status: 400
-});
+class BundleError extends BaseError {
+    constructor(info) {
+        super('BundleError', 'JS-BUNDLE-ERROR', 400, info);
+    }
+}
 
-errors.JobNotFoundError = BaseError.extend({
-    name: 'JobNotFoundError',
-    code: 'JS-JOB-NOT-FOUND-ERROR',
-    status: 404
-});
+class JobNotFoundError extends BaseError {
+    constructor(info) {
+        super('JobNotFoundError', 'JS-JOB-NOT-FOUND-ERROR', 404, info);
+    }
+}
 
-errors.FileNotFoundError = BaseError.extend({
-    name: 'FileNotFoundError',
-    code: 'JS-FILE-NOT-FOUND-ERROR',
-    status: 404
-});
+class FileNotFoundError extends BaseError {
+    constructor(info) {
+        super('FileNotFoundError', 'JS-FILE-NOT-FOUND-ERROR', 404, info);
+    }
+}
 
-errors.FileAccessError = BaseError.extend({
-    name: 'FileAccessError',
-    code: 'JS-FILE-ACCESS-ERROR',
-    status: 403
-});
+class FileAccessError extends BaseError {
+    constructor(info) {
+        super('FileAccessError', 'JS-FILE-ACCESS-ERROR', 403, info);
+    }
+}
 
-errors.DirectoryNotFoundError = BaseError.extend({
-    name: 'DirectoryNotFoundError',
-    code: 'JS-DIR-NOT-FOUND-ERROR',
-    status: 404
-});
+class DirectoryNotFoundError extends BaseError {
+    constructor(info) {
+        super('DirectoryNotFoundError', 'JS-DIR-NOT-FOUND-ERROR', 404, info);
+    }
+}
 
-errors.DirectoryAccessError = BaseError.extend({
-    name: 'DirectoryAccessError',
-    code: 'JS-DIR-ACCESS-ERROR',
-    status: 403
-});
+class DirectoryAccessError extends BaseError {
+    constructor(info) {
+        super('DirectoryAccessError', 'JS-DIR-ACCESS-ERROR', 403, info);
+    }
+}
 
-errors.InvalidPathError = BaseError.extend({
-    name: 'InvalidPathError',
-    code: 'JS-INVALID-PATH-ERROR',
-    status: 400
-});
+class InvalidPathError extends BaseError {
+    constructor(info) {
+        super('InvalidPathError', 'JS-INVALID-PATH-ERROR', 400, info);
+    }
+}
 
-errors.TimeoutError = BaseError.extend({
-    name: 'TimeoutError',
-    code: 'JS-TIMEOUT-ERROR',
-    status: 408
-});
+class TimeoutError extends BaseError {
+    constructor(info) {
+        super('TimeoutError', 'JS-TIMEOUT-ERROR', 408, info);
+    }
+}
 
 errors.unknownError = function(err) {
-    return new errors.UnknownError({err: err});
+    return new UnknownError({err: err});
 };
 
 errors.juttleError = function(err, bundle) {
-    return new errors.JuttleError({err: err, bundle: bundle});
+    return new JuttleError({err: err, bundle: bundle});
 };
 
 errors.bundleError = function(reason, bundle) {
-    return new errors.BundleError({reason: reason, bundle: bundle});
+    return new BundleError({reason: reason, bundle: bundle});
 };
 
 errors.jobNotFoundError = function(job_id) {
-    return new errors.JobNotFoundError({job_id: job_id});
+    return new JobNotFoundError({job_id: job_id});
 };
 
 errors.fileNotFoundError = function(path) {
-    return new errors.FileNotFoundError({path: path});
+    return new FileNotFoundError({path: path});
 };
 
 errors.fileAccessError = function(path) {
-    return new errors.FileAccessError({path: path});
+    return new FileAccessError({path: path});
 };
 
 errors.directoryNotFoundError = function(path) {
-    return new errors.DirectoryNotFoundError({path: path});
+    return new DirectoryNotFoundError({path: path});
 };
 
 errors.directoryAccessError = function(path) {
-    return new errors.DirectoryAccessError({path: path});
+    return new DirectoryAccessError({path: path});
 };
 
 errors.invalidPathError = function(path) {
-    return new errors.InvalidPathError({path: path});
+    return new InvalidPathError({path: path});
 };
 
 errors.timeoutError = function(timeout) {
-    return new errors.TimeoutError({timeout: timeout});
+    return new TimeoutError({timeout: timeout});
 };
 
 errors.is_juttle_service_error = function(err) {
-    return (err instanceof errors.UnknownError ||
-            err instanceof errors.JuttleError ||
-            err instanceof errors.BundleError ||
-            err instanceof errors.JobNotFoundError ||
-            err instanceof errors.FileNotFoundError ||
-            err instanceof errors.FileAccessError ||
-            err instanceof errors.DirectoryNotFoundError ||
-            err instanceof errors.DirectoryAccessError ||
-            err instanceof errors.InvalidPathError ||
-            err instanceof errors.TimeoutError);
+    return (err instanceof UnknownError ||
+            err instanceof JuttleError ||
+            err instanceof BundleError ||
+            err instanceof JobNotFoundError ||
+            err instanceof FileNotFoundError ||
+            err instanceof FileAccessError ||
+            err instanceof DirectoryNotFoundError ||
+            err instanceof DirectoryAccessError ||
+            err instanceof InvalidPathError ||
+            err instanceof TimeoutError);
 };
 
 module.exports = errors;

--- a/lib/immediate-juttle-job.js
+++ b/lib/immediate-juttle-job.js
@@ -4,8 +4,9 @@ var _ = require('underscore');
 var logger = require('log4js').getLogger('juttle-job');
 var JuttleJob = require('./juttle-job');
 
-var ImmediateJuttleJob = JuttleJob.extend({
-    initialize: function(options) {
+class ImmediateJuttleJob extends JuttleJob {
+    constructor(options) {
+        super(options);
         var self = this;
 
         self._timeout = options.timeout || 60000;
@@ -19,9 +20,9 @@ var ImmediateJuttleJob = JuttleJob.extend({
 
         // Any warnings for this program.
         self._warnings = [];
-    },
+    }
 
-    _on_job_msg: function(msg) {
+    _on_job_msg(msg) {
         var self = this;
 
         // Remove the job_id from the message, it isn't necessary.
@@ -63,9 +64,9 @@ var ImmediateJuttleJob = JuttleJob.extend({
                 lastData.points = lastData.points.concat(msg.points);
             }
         }
-    },
+    }
 
-    start: function() {
+    start() {
         var self = this;
 
         // Call JuttleJob's start() method, which starts the
@@ -82,9 +83,9 @@ var ImmediateJuttleJob = JuttleJob.extend({
                 warnings: self._warnings
             };
         });
-    },
+    }
 
-    waitfor: function() {
+    waitfor() {
         var self = this;
 
         // Create a promise that resolves when we receive an 'end'. It
@@ -97,6 +98,6 @@ var ImmediateJuttleJob = JuttleJob.extend({
             });
         }).timeout(self._timeout, self._job_id + ' timed out');
     }
-});
+}
 
 module.exports = ImmediateJuttleJob;

--- a/lib/job-handlers.js
+++ b/lib/job-handlers.js
@@ -36,7 +36,7 @@ function create_job(req, res, next) {
     } else {
         if (! _.has(req.body.bundle, 'program')) {
             var err = JuttleServiceErrors.bundleError('Bundle does not contain program property', req.body.bundle);
-            return res.status(err.status).send(err);
+            return res.status(err.status()).send(err);
         }
         bundle_promise = Promise.resolve({bundle: req.body.bundle});
     }
@@ -66,7 +66,7 @@ function create_job(req, res, next) {
         job_mgr.delete_job(job_id);
 
         var err = JuttleServiceErrors.timeoutError(req.body.timeout);
-        res.status(err.status).send(err);
+        res.status(err.status()).send(err);
     }).catch(next);
 }
 
@@ -75,7 +75,7 @@ function delete_job(req, res, next) {
         res.status(200).send({});
     } else {
         var err = JuttleServiceErrors.jobNotFoundError(req.params.job_id);
-        res.status(err.status).send(err);
+        res.status(err.status()).send(err);
     }
 }
 
@@ -92,7 +92,7 @@ function list_job(req, res, next) {
     var job = job_mgr.get_job(req.params.job_id);
     if (! job) {
         var err = JuttleServiceErrors.jobNotFoundError(req.params.job_id);
-        res.status(err.status).send(err);
+        res.status(err.status()).send(err);
     } else {
         res.status(200).send(job.describe());
     }

--- a/lib/job-manager.js
+++ b/lib/job-manager.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var _ = require('underscore');
-var Base = require('extendable-base');
 var uuid = require('uuid');
 var logger = require('log4js').getLogger('job-manager');
 var EventEmitter = require('events');
@@ -12,9 +11,8 @@ var ImmediateJuttleJob = require('./immediate-juttle-job');
 // also brings together websocket endpoints and the outputs (sinks) of
 // running juttle programs.
 
-var JobManager = Base.extend({
-
-    initialize: function(options) {
+class JobManager {
+    constructor(options) {
         var self = this;
 
         self._config_path = options.config_path;
@@ -29,19 +27,19 @@ var JobManager = Base.extend({
         // This object emits job_start/job_end events when jobs are
         // started and deleted.
         self.events = new EventEmitter();
-    },
+    }
 
     // Returns an array of job objects for all active jobs.
-    get_all_jobs: function() {
+    get_all_jobs() {
         var self = this;
 
         return _.values(self._jobs);
-    },
+    }
 
     // Return the job object associated with the given job id, or
     // undefined if no job exists for that job id.
 
-    get_job: function(job_id) {
+    get_job(job_id) {
         var self = this;
 
         if (! _.has(self._jobs, job_id)) {
@@ -49,9 +47,9 @@ var JobManager = Base.extend({
         } else {
             return self._jobs[job_id];
         }
-    },
+    }
 
-    delete_job: function(job_id) {
+    delete_job(job_id) {
         var self = this;
 
         if (_.has(self._jobs, job_id)) {
@@ -67,9 +65,9 @@ var JobManager = Base.extend({
         } else {
             return undefined;
         }
-    },
+    }
 
-    run_program: function(options) {
+    run_program(options) {
         var self = this;
 
         options.inputs = options.inputs || {};
@@ -138,6 +136,6 @@ var JobManager = Base.extend({
         // id and pid.
         return job.start();
     }
-});
+}
 
 module.exports = JobManager;

--- a/lib/juttle-job.js
+++ b/lib/juttle-job.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var _ = require('underscore');
-var Base = require('extendable-base');
 var JSDP = require('juttle-jsdp');
 var JSDPValueConverter = require('./jsdp-value-converter');
 var child_process = require('child_process');
@@ -18,8 +17,8 @@ var EventEmitter = require('events');
 // http clients is handled by subclasses. Based on the method, the Job
 // Manager will create an object of one of the subclasses.
 
-var JuttleJob = Base.extend({
-    initialize: function(options) {
+class JuttleJob {
+    constructor(options) {
         var self = this;
 
         self._job_id = options.job_id;
@@ -39,18 +38,18 @@ var JuttleJob = Base.extend({
         self._job_stopped = false;
 
         logger.debug(self._log_prefix + 'Created job');
-    },
+    }
 
-    describe: function() {
+    describe() {
         var self = this;
 
         return {
             job_id: self._job_id,
             bundle: self._bundle
         };
-    },
+    }
 
-    start: function() {
+    start() {
         var self = this;
 
         logger.debug(self._log_prefix + 'Starting job');
@@ -150,9 +149,9 @@ var JuttleJob = Base.extend({
         self._child.send({cmd: 'run', bundle: self._bundle, inputs: JSDP.serialize(JSDPValueConverter.convertToJSDPValue(self._inputs), { toObject: true })});
 
         return child_started;
-    },
+    }
 
-    stop: function() {
+    stop() {
         var self = this;
 
         logger.debug(self._log_prefix + 'Stopping job');
@@ -163,13 +162,12 @@ var JuttleJob = Base.extend({
         if (self._child) {
             self._child.send({cmd: 'stop'});
         }
-    },
+    }
 
     // Send a message to whoever is listening to the output of this
     // job. This method should be overridden by subclasses.
-    _on_job_msg: function(msg) {
+    _on_job_msg(msg) {
     }
-
-});
+}
 
 module.exports = JuttleJob;

--- a/lib/observer-manager.js
+++ b/lib/observer-manager.js
@@ -1,12 +1,10 @@
 'use strict';
 
 var _ = require('underscore');
-var Base = require('extendable-base');
 var logger = require('log4js').getLogger('observer-manager');
 
-var ObserverManager = Base.extend({
-
-    initialize: function(options) {
+class ObserverManager {
+    constructor(options) {
         var self = this;
 
         self._job_mgr = options.job_mgr;
@@ -24,10 +22,10 @@ var ObserverManager = Base.extend({
         // mentions that observer id, all the endpoints related to
         // that observer id are notified.
         self._observers = {};
-    },
+    }
 
     // notify any observers on observer_id of the event related to job_id
-    notify_observers: function(job_event, job_id, observer_id) {
+    notify_observers(job_event, job_id, observer_id) {
         var self = this;
 
         // If this run request includes an observer id, notify all
@@ -38,18 +36,18 @@ var ObserverManager = Base.extend({
                 endpoint.send({type: job_event, job_id: job_id});
             });
         }
-    },
+    }
 
     // Return a description of all observers. This is currently just a list of observer ids
-    list_observers: function() {
+    list_observers() {
         var self = this;
 
         return _.map(_.keys(self._observers), function(observer_id) {
             return {observer_id: observer_id};
         });
-    },
+    }
 
-    add_endpoint_to_observer: function(endpoint, observer_id) {
+    add_endpoint_to_observer(endpoint, observer_id) {
         var self = this;
 
         logger.debug('Adding endpoint ' + endpoint.describe() + ' to observer ' + observer_id);
@@ -65,9 +63,9 @@ var ObserverManager = Base.extend({
         endpoint.events.on('close', function() {
             self.remove_endpoint_from_observer_id(endpoint, observer_id);
         });
-    },
+    }
 
-    remove_endpoint_from_observer_id: function(endpoint, observer_id) {
+    remove_endpoint_from_observer_id(endpoint, observer_id) {
         var self = this;
 
         logger.debug('Removing endpoint ' + endpoint.describe() + ' from observer ' + observer_id);
@@ -78,6 +76,6 @@ var ObserverManager = Base.extend({
             delete self._observers[observer_id];
         }
     }
-});
+}
 
 module.exports = ObserverManager;

--- a/lib/prepare-handlers.js
+++ b/lib/prepare-handlers.js
@@ -47,7 +47,7 @@ function get_inputs(req, res, next) {
             // with the error so the client can display the error in
             // context.
             var err_with_context = JuttleServiceErrors.juttleError(err, req.body.bundle);
-            res.status(err_with_context.status).send(err_with_context);
+            res.status(err_with_context.status()).send(err_with_context);
         } else {
             // Pass along the error so it will be picked up by
             // default_error_handler.

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -31,7 +31,7 @@ function default_error_handler(err, req, res, next) {
         });
     }
 
-    res.status(err.status).send(err);
+    res.status(err.status()).send(err);
 }
 
 function add_routes(app, options) {

--- a/lib/websocket-endpoint.js
+++ b/lib/websocket-endpoint.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var _ = require('underscore');
-var Base = require('extendable-base');
 var Promise = require('bluebird');
 var logger = require('log4js').getLogger('websocket-endpoint');
 var WebSocket = require('ws');
@@ -13,8 +12,8 @@ var Deque = require('double-ended-queue');
 // authentication. Once authenticated, it passes the socket off to the
 // JobManager object to connect the job and the websocket connection.
 
-var WebsocketEndpoint = Base.extend({
-    initialize: function(options) {
+class WebsocketEndpoint {
+    constructor(options) {
         var self = this;
 
         this._ws = options.ws;
@@ -45,14 +44,14 @@ var WebsocketEndpoint = Base.extend({
             self.ping();
         }, this._ping_interval);
         logger.info('Successfully created Websocket Endpoint');
-    },
+    }
 
-    describe: function() {
+    describe() {
         return this._ws.upgradeReq.socket.remoteAddress +
             ':' + this._ws.upgradeReq.socket.remotePort;
-    },
+    }
 
-    message: function(message) {
+    message(message) {
         var self = this;
 
         try {
@@ -71,9 +70,9 @@ var WebsocketEndpoint = Base.extend({
 
         // Emit a message event with the message.
         self.events.emit('message', message);
-    },
+    }
 
-    close: function(force) {
+    close(force) {
         var self = this;
 
         force = force || false;
@@ -104,9 +103,9 @@ var WebsocketEndpoint = Base.extend({
         // job-manager.js to remove the endpoint from the appropriate
         // aliases.
         self.events.emit('close');
-    },
+    }
 
-    ping: function() {
+    ping() {
         var self = this;
         self._ping_counter += 1;
 
@@ -122,20 +121,20 @@ var WebsocketEndpoint = Base.extend({
             clearInterval(this._ping_interval);
             this._ping_interval = null;
         }
-    },
+    }
 
-    pong: function() {
+    pong() {
         this._ping_counter = 0;
-    },
+    }
 
-    send: function(data) {
+    send(data) {
         var self = this;
 
         self._message_queue.enqueue(data);
         self.drain();
-    },
+    }
 
-    send_many: function(datas) {
+    send_many(datas) {
         var self = this;
 
         datas.forEach(function(data) {
@@ -143,9 +142,9 @@ var WebsocketEndpoint = Base.extend({
         });
 
         self.drain();
-    },
+    }
 
-    drain: function() {
+    drain() {
         var self = this;
 
         if (self._ws.readyState !== WebSocket.OPEN) {
@@ -169,7 +168,6 @@ var WebsocketEndpoint = Base.extend({
                 }
             });
     }
-
-});
+}
 
 module.exports = WebsocketEndpoint;

--- a/lib/ws-juttle-job.js
+++ b/lib/ws-juttle-job.js
@@ -5,8 +5,9 @@ var CBuffer = require('CBuffer');
 var logger = require('log4js').getLogger('juttle-job');
 var JuttleJob = require('./juttle-job');
 
-var WebsocketJuttleJob = JuttleJob.extend({
-    initialize: function(options) {
+class WebsocketJuttleJob extends JuttleJob {
+    constructor(options) {
+        super(options);
         var self = this;
 
         // An array of WebsocketEndpoint objects.
@@ -37,22 +38,22 @@ var WebsocketJuttleJob = JuttleJob.extend({
                 });
             }, self._delayed_endpoint_close);
         });
-    },
+    }
 
-    save: function(msg) {
+    save(msg) {
         var self = this;
 
         self._saved_messages.push(msg);
-    },
+    }
 
-    replay: function(endpoint) {
+    replay(endpoint) {
         var self = this;
 
         // This works because CBuffer implements forEach.
         endpoint.send_many(self._saved_messages);
-    },
+    }
 
-    describe: function() {
+    describe() {
         var self = this;
 
         var ep_desc = _.map(self._endpoints, function(endpoint) {
@@ -64,9 +65,9 @@ var WebsocketJuttleJob = JuttleJob.extend({
             bundle: self._bundle,
             endpoints: ep_desc
         };
-    },
+    }
 
-    add_endpoint: function(endpoint) {
+    add_endpoint(endpoint) {
         var self = this;
 
         logger.debug(self._log_prefix + 'Adding endpoint');
@@ -100,9 +101,9 @@ var WebsocketJuttleJob = JuttleJob.extend({
         endpoint.events.on('close', function() {
             self.remove_endpoint(endpoint);
         });
-    },
+    }
 
-    remove_endpoint: function(endpoint) {
+    remove_endpoint(endpoint) {
         var self = this;
 
         logger.debug(self._log_prefix + 'Removing endpoint');
@@ -116,9 +117,9 @@ var WebsocketJuttleJob = JuttleJob.extend({
             // Stop the job.
             self.stop();
         }
-    },
+    }
 
-    _on_job_msg: function(msg) {
+    _on_job_msg(msg) {
         var self = this;
 
         // If this is a job_start or job_end message, save it
@@ -136,6 +137,6 @@ var WebsocketJuttleJob = JuttleJob.extend({
             endpoint.send(msg);
         });
     }
-});
+}
 
 module.exports = WebsocketJuttleJob;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "double-ended-queue": "^0.9.7",
     "express": "^4.13.4",
     "express-ws": "^1.0.0-rc.2",
-    "extendable-base": "^0.3.1",
     "fs-extra": "^0.26.5",
     "juttle-jsdp": "^0.1.1",
     "log4js": "^0.6.30",


### PR DESCRIPTION
Run the script at https://gist.github.com/demmer/562cfc2343cc9d049b69
to convert all the extendable-base classes to ES6 classes.

This also required a rework of how the error classes were implemented.