### PR TITLE
add: debug option to retrieve logs

### DIFF
--- a/docs/jobs-api.md
+++ b/docs/jobs-api.md
@@ -142,6 +142,8 @@ POST /api/v0/jobs HTTP/1.1
 
 Note the `timeout` property in the body. If a program runs for more than *timeout* ms, the program is aborted and an error is returned. If not specified, *timeout* is 60000 (60 seconds).
 
+When the `debug` property in the body is set to `true` the response body will contain a `logs` array and a `log` event will be published to the websocket. 
+
 ###GET /api/v0/jobs/*jobID*
 
 If specified with a websocket upgrade header, GET upgrades the http connection to a websocket to receive data and meta-data for the indicated job over JSDP.  The system buffers initial data (to configurable limit) from the running job until the first receiver attaches through this endpoint and bursts out this initial data, while subsequent instances will start receiving the data in midstream beginning with the time they connect. Any number of clients can connect to this endpoint and each will receive their own stream points over JSDP.

--- a/docs/jsdp-api.md
+++ b/docs/jsdp-api.md
@@ -17,6 +17,7 @@ The Juttle Service can send the following messages:
 | points | An array of points for a given view
 | tick | A data-less point
 | mark | Indicates the end of a batch
+| log | An object containing one log message from the subprocess.
 | points_processed | Current count of points the Juttle Service has processed for current program
 | view_end | The execution for a given view has ended
 | job_end | The current job has ended
@@ -124,6 +125,19 @@ Reflects the end of a batch.
   }
 ```
 
+#### log
+
+Sent as logs come in when program started with debug parameter set.
+
+```
+{
+  type: 'log',
+  name: 'log-name',
+  level: 'log-level',
+  arguments: [ 'foo', 'bar' ]
+  }
+```
+
 #### view_end
 
 Sent to indicate that a view is finished and will not send any more points.
@@ -155,4 +169,3 @@ after several pings, the Juttle Service will close the websocket connection.
     type: "pong"
 }
 ```
-

--- a/lib/immediate-juttle-job.js
+++ b/lib/immediate-juttle-job.js
@@ -20,6 +20,9 @@ class ImmediateJuttleJob extends JuttleJob {
 
         // Any warnings for this program.
         self._warnings = [];
+
+        // Any logs for this program.
+        self._logs = [];
     }
 
     _on_job_msg(msg) {
@@ -43,6 +46,8 @@ class ImmediateJuttleJob extends JuttleJob {
             // We actually wait until close() to return the data.
         } else if (msg.type === 'error') {
             self._errors.push(msg.error);
+        } else if (msg.type === 'log') {
+            self._logs.push(msg);
         } else if (msg.type === 'warning') {
             self._warnings.push(msg.warning);
         } else if (msg.type === 'mark') {
@@ -77,11 +82,16 @@ class ImmediateJuttleJob extends JuttleJob {
         .then(function() {
             return self.waitfor();
         }).then(function() {
-            return {
+            var result = {
                 output: self._program_output,
                 errors: self._errors,
                 warnings: self._warnings
             };
+
+            if (self._debug) {
+                result.logs = self._logs;
+            }
+            return result;
         });
     }
 

--- a/lib/job-handlers.js
+++ b/lib/job-handlers.js
@@ -47,6 +47,7 @@ function create_job(req, res, next) {
                                     inputs: JSDPValueConverter.convertToJuttleValue(JSDP.deserialize(req.body.inputs || {})),
                                     observer_id: req.body.observer,
                                     wait: req.body.wait,
+                                    debug: req.body.debug,
                                     timeout: req.body.timeout});
     })
     .then(function(results) {

--- a/lib/job-manager.js
+++ b/lib/job-manager.js
@@ -90,6 +90,7 @@ class JobManager {
         var job_options = {job_id: job_id,
                            bundle: options.bundle,
                            inputs: options.inputs,
+                           debug: options.debug,
                            config_path: self._config_path};
 
         if (options.wait) {

--- a/lib/juttle-job.js
+++ b/lib/juttle-job.js
@@ -26,6 +26,7 @@ class JuttleJob {
 
         self._bundle = options.bundle;
         self._inputs = options.inputs;
+        self._debug = options.debug;
         self._config_path = options.config_path;
 
         // A handle to the spawned child process where the juttle
@@ -74,6 +75,9 @@ class JuttleJob {
                 case 'log':
                     var processLogger = require('log4js').getLogger(msg.name);
                     processLogger[msg.level].apply(processLogger, msg.arguments);
+                    if (self._debug) {
+                        self._on_job_msg(msg);
+                    }
                     break;
                 case 'done':
                     logger.info('subprocess done');


### PR DESCRIPTION
1. create job route accepts a debug option.
2. logs are emitted through the websocket with message type=log.
3. Logs are sent back in the response body when using -wait option.

resolves https://github.com/juttle/juttle-service/issues/42