### PR TITLE
Don't dequeue from an empty message queue.

### DIFF
--- a/lib/websocket-endpoint.js
+++ b/lib/websocket-endpoint.js
@@ -147,7 +147,8 @@ class WebsocketEndpoint {
     drain() {
         var self = this;
 
-        if (self._ws.readyState !== WebSocket.OPEN) {
+        if (self._ws.readyState !== WebSocket.OPEN ||
+            self._message_queue.isEmpty()) {
             return;
         }
 


### PR DESCRIPTION
When calling drain(), exit early when the message queue is empty. This
should be extremely uncommon, as drain() is only called as a part of a
call to send() or send_many(), both of which should add items to the
queue.

However, there is a potential race condition related to replaying
messages over a websocket where a client starts a job and connects to
the websocket before the juttle service has received the first point
from the subprocess. In that case, WebsocketJuttleJob's add_endpoint
method would call replay() on an empty list of _saved messages and
then call drain.

This could be fixed by not calling replay() when there are no saved
messages, but the safest place to fix the problem is to not dequeue
anything at all when the message queue is empty.

This fixes #17.

@go-oleg 