### PR TITLE
juttle-subprocess.spec.js: deserialize log messages before asserting the value is correct

### DIFF
--- a/test/juttle-subprocess.spec.js
+++ b/test/juttle-subprocess.spec.js
@@ -120,7 +120,7 @@ describe('juttle-subprocess', function() {
             return waitForMessage({ type: 'log', level: 'warn' });
         })
         .then(function() {
-            var message = findMessage({ type: 'log', level: 'warn' });
+            var message = JSDP.deserialize(findMessage({ type: 'log', level: 'warn' }));
             expect(message.arguments[0]).to.contain('Invalid operand types for "+": number (0) and date (2014-01-01T00:00:00.000Z)');
             // verify location data is provided
             expect(message.arguments[1].info.location).to.not.be.undefined;
@@ -146,7 +146,7 @@ describe('juttle-subprocess', function() {
             return waitForMessage({ type: 'log', level: 'error' });
         })
         .then(function() {
-            var message = findMessage({ type: 'log', level: 'error' });
+            var message = JSDP.deserialize(findMessage({ type: 'log', level: 'error' }));
             expect(message.arguments[0]).to.contain('ENOENT: no such file or directory, open \'inexistent\'');
 
             // verify location data is provided


### PR DESCRIPTION
Because of the fix in https://github.com/juttle/pluggable-json/pull/4, values that weren't being correctly serialized previously are getting serialized now. Making sure we deserialize them in the tests before asserting the values are correct.

In general, I think it would be cleaner to just serialize everything coming out of the subprocess and deserialize as soon as it gets into the parent process. That is, messages should not be stored in the parent process in a serialized state. However, that would mean we would have to serialize _again_ before sending across the websocket or in the HTTP response which is meh. Lets discuss but make any changes we decide on in a followup PR?

@VladVega @mstemm @demmer 