### PR TITLE
change lingering 'sink' references to 'view'

### DIFF
--- a/docs/jsdp-api.md
+++ b/docs/jsdp-api.md
@@ -14,11 +14,11 @@ The Juttle Service can send the following messages:
 |-------|------------
 | ping | Periodically sent from server to indicate the client has successfully connected
 | job_start | A new juttle program has started
-| points | An array of points for a given sink
+| points | An array of points for a given view
 | tick | A data-less point
 | mark | Indicates the end of a batch
 | points_processed | Current count of points the Juttle Service has processed for current program
-| sink_end | The execution for a given sink has ended
+| view_end | The execution for a given view has ended
 | job_end | The current job has ended
 
 ### Sending Events
@@ -49,9 +49,9 @@ Sent when a new program is executed.
 {
 "type": "job_start",
   "job_id": "edb5a183-bd74-4ec7-870f-db20c84d45ab",
-  "sinks": [{
+  "views": [{
       "type": "logger"
-      "sink_id": "sink0",
+      "view_id": "view0",
       "options": {
         "display": {
           "style": "raw"
@@ -60,7 +60,7 @@ Sent when a new program is executed.
     },
     {
       "type": "table"
-      "sink_id": "sink1",
+      "view_id": "view1",
       "options": {}
     }],
   inputs: [{
@@ -77,19 +77,19 @@ Sent when a new program is executed.
 
 The `job_id` property is a unique identifier for the currrent job (i.e. running program). It should be used by clients when reattaching to a job.
 
-The `sinks` property is an array of objects describing the sinks for the new program. In a given sink object the `type` property specifies the type of sink while the `sink_id` property is a unique identifier for this sink, that we remain constant throughout the lifecycle of the current job.
+The `views` property is an array of objects describing the views for the new program. In a given view object the `type` property specifies the type of view while the `view_id` property is a unique identifier for this view, that we remain constant throughout the lifecycle of the current job.
 
 The `inputs` property is an array of objects describing the juttle-inputs for the given program. The `name` property is a unique identifier for the input. The `type` property specifies the type of input, `value` denotes the selected value for the input and the `values` attribute (optional) is an array of possible for values for the input.
 
 #### points
 
-Sent when a new set of points are available for display/handling by a given sink.
+Sent when a new set of points are available for display/handling by a given view.
 
 ```
 {
   "type": "points",
   "job_id": "edb5a183-bd74-4ec7-870f-db20c84d45ab",
-  "sink_id": "sink0",
+  "view_id": "view0",
   "points": [{
       "foo": "bar",
       "time": "2015-11-14T02:39:49.833Z"
@@ -97,7 +97,7 @@ Sent when a new set of points are available for display/handling by a given sink
   }
 ```
 
-The message includes the job id, sink id, and an array of points.
+The message includes the job id, view id, and an array of points.
 
 #### tick
 
@@ -106,7 +106,7 @@ Sent periodically to show time progression.
 {
   "type": "tick",
   "job_id": "edb5a183-bd74-4ec7-870f-db20c84d45ab",
-  "sink_id": "sink0",
+  "view_id": "view0",
   "time": "2015-11-14T02:39:48.833Z",
 }
 ```
@@ -120,19 +120,19 @@ Reflects the end of a batch.
   "time": "2015-11-16T16:57:33.000Z",
   "type": "mark",
   "job_id": "edb5a183-bd74-4ec7-870f-db20c84d45ab",
-  "sink_id": "sink0",
+  "view_id": "view0",
   }
 ```
 
-#### sink_end
+#### view_end
 
-Sent to indicate that a sink is finished and will not send any more points.
+Sent to indicate that a view is finished and will not send any more points.
 
 ```
 {
-  "type": "sink_end",
+  "type": "view_end",
   "job_id": "edb5a183-bd74-4ec7-870f-db20c84d45ab",
-  "sink_id": "sink0",
+  "view_id": "view0",
   }
 ```
 

--- a/lib/immediate-juttle-job.js
+++ b/lib/immediate-juttle-job.js
@@ -11,7 +11,7 @@ class ImmediateJuttleJob extends JuttleJob {
 
         self._timeout = options.timeout || 60000;
 
-        // The output of this program, as a hash sink_id -> sink
+        // The output of this program, as a hash view_id -> view
         // description + array of points.
         self._program_output = {};
 
@@ -31,9 +31,9 @@ class ImmediateJuttleJob extends JuttleJob {
         // If this is a job_start or job_end message, save it
         // separately.
         if (msg.type === 'job_start') {
-            // Initialize _program_output from the sink descriptions.
-            msg.sinks.forEach(function(desc) {
-                self._program_output[desc.sink_id] = {
+            // Initialize _program_output from the view descriptions.
+            msg.views.forEach(function(desc) {
+                self._program_output[desc.view_id] = {
                     options: desc.options,
                     type: desc.type,
                     data: []
@@ -46,11 +46,11 @@ class ImmediateJuttleJob extends JuttleJob {
         } else if (msg.type === 'warning') {
             self._warnings.push(msg.warning);
         } else if (msg.type === 'mark') {
-            var data = _.omit(msg, 'sink_id');
-            // Append the data to the appropriate sink's array of data.
-            self._program_output[msg.sink_id].data.push(data);
+            var data = _.omit(msg, 'view_id');
+            // Append the data to the appropriate view's array of data.
+            self._program_output[msg.view_id].data.push(data);
         } else if (msg.type === 'points') {
-            var currentData = self._program_output[msg.sink_id].data;
+            var currentData = self._program_output[msg.view_id].data;
             var lastData = _.last(currentData);
             // If the most recently buffered data is not a points entry, create one.
             // Otherwise, concat the new points into the last entry.

--- a/lib/job-manager.js
+++ b/lib/job-manager.js
@@ -8,7 +8,7 @@ var WebsocketJuttleJob = require('./ws-juttle-job');
 var ImmediateJuttleJob = require('./immediate-juttle-job');
 
 // This class handles management of jobs (running juttle programs). It
-// also brings together websocket endpoints and the outputs (sinks) of
+// also brings together websocket endpoints and the outputs (views) of
 // running juttle programs.
 
 class JobManager {

--- a/lib/juttle-job.js
+++ b/lib/juttle-job.js
@@ -132,7 +132,7 @@ class JuttleJob {
                         self._received_program_started = true;
                         self._on_job_msg({type: 'job_start',
                                               job_id: self._job_id,
-                                              sinks: msg.sinks});
+                                              views: msg.views});
                         resolve({job_id: self._job_id, pid: self._child.pid});
                         break;
                     case 'juttle_error':

--- a/lib/juttle-subprocess.js
+++ b/lib/juttle-subprocess.js
@@ -3,8 +3,8 @@
 // This script is intended for use as a spawned subprocess by
 // JuttleJob. It waits for a message from the parent containing the
 // job id and program to run, compiles the program, writes the set of
-// sink descriptors as a message, and then streams the data for the
-// sinks as messages.
+// view descriptors as a message, and then streams the data for the
+// views as messages.
 
 // Before any other modules are loaded, override the juttle logging subsystem to
 // create a wrapper that sends logs to be emitted by the parent process.
@@ -76,36 +76,36 @@ process.on('message', function(msg) {
         var bundle = msg.bundle;
 
         // Run the juttle program. The two things written to standard out are:
-        //  - A description of the sinks
-        //  - A stream of all the data for the sinks
+        //  - A description of the views
+        //  - A stream of all the data for the views
 
         logger.info('starting-juttle-program', bundle.program);
 
         var compile_options = {
             stage: 'eval',
-            fg_processors: [implicit_views(config.implicit_sink || 'table'), optimize, views_sourceinfo],
+            fg_processors: [implicit_views(config.implicit_view || 'table'), optimize, views_sourceinfo],
             inputs: JSDPValueConverter.convertToJuttleValue(JSDP.deserialize(msg.inputs || {})),
             modules: msg.bundle.modules
         };
 
         compiler.compile(msg.bundle.program, compile_options)
         .then(function(program) {
-            // Maps from channel to sink id
-            var sink_descs = _.map(program.get_views(program), function(sink) {
+            // Maps from channel to view id
+            var view_descs = _.map(program.get_views(program), function(view) {
                 return {
-                    type: sink.name,
-                    sink_id: sink.channel,
-                    options: sink.options
+                    type: view.name,
+                    view_id: view.channel,
+                    options: view.options
                 };
             });
 
             send({
                 type: 'program_started',
-                sinks: sink_descs
+                views: view_descs
             });
 
             // Start listening for callbacks from the interpreter for
-            // errors/warnings/sink data.
+            // errors/warnings/view data.
             program.events.on('error', function(msg, err) {
                 logger.error(msg, err);
                 send({
@@ -127,7 +127,7 @@ process.on('message', function(msg) {
                     type: 'data', data: {
                         type: 'mark',
                         time: data.time,
-                        sink_id: data.channel
+                        view_id: data.channel
                     }
                 });
             });
@@ -137,7 +137,7 @@ process.on('message', function(msg) {
                     type: 'data', data: {
                         type: 'tick',
                         time: data.time,
-                        sink_id: data.channel
+                        view_id: data.channel
                     }
                 });
             });
@@ -145,8 +145,8 @@ process.on('message', function(msg) {
             program.events.on('view:eof', function(data) {
                 send({
                     type: 'data', data: {
-                        type: 'sink_end',
-                        sink_id: data.channel
+                        type: 'view_end',
+                        view_id: data.channel
                     }
                 });
             });
@@ -156,7 +156,7 @@ process.on('message', function(msg) {
                     type: 'data', data: {
                         type: 'points',
                         points: data.points,
-                        sink_id: data.channel
+                        view_id: data.channel
                     }
                 });
             });

--- a/lib/prepare-handlers.js
+++ b/lib/prepare-handlers.js
@@ -20,7 +20,7 @@ function get_inputs(req, res, next) {
 
     var compile_options = {
         stage: 'flowgraph',
-        fg_processors: [implicit_views(config.implicit_sink || 'table'), optimize],
+        fg_processors: [implicit_views(config.implicit_view || 'table'), optimize],
         inputs: JSDPValueConverter.convertToJuttleValue(JSDP.deserialize(req.body.inputs || {})),
         modules: req.body.bundle.modules
     };

--- a/test/juttle-service.spec.js
+++ b/test/juttle-service.spec.js
@@ -1168,7 +1168,7 @@ describe('Juttle Service Tests', function() {
                     var num_points = 0;
                     var num_ticks = 0;
                     var num_marks = 0;
-                    var num_sink_ends = 0;
+                    var num_view_ends = 0;
                     var got_job_end_time = undefined;
                     ws_client = new WebSocket(juttleBaseUrl + '/jobs/' + job_id);
                     ws_client.on('message', function(data) {
@@ -1177,26 +1177,26 @@ describe('Juttle Service Tests', function() {
                         if (data.type === 'job_start') {
                             got_job_start = true;
                             expect(data.job_id === job_id);
-                            expect(data.sinks[0].sink_id).to.match(/view\d+/);
-                            expect(data.sinks[1].sink_id).to.match(/view\d+/);
+                            expect(data.views[0].view_id).to.match(/view\d+/);
+                            expect(data.views[1].view_id).to.match(/view\d+/);
 
-                            // Change the sink ids to just "sink" to
+                            // Change the view ids to just "view" to
                             // allow for an exact match of the full
-                            // sink description.
-                            data.sinks[0].sink_id = 'sink';
-                            data.sinks[1].sink_id = 'sink';
+                            // view description.
+                            data.views[0].view_id = 'view';
+                            data.views[1].view_id = 'view';
 
-                            expect(data.sinks).to.deep.equal([
+                            expect(data.views).to.deep.equal([
                                 {
                                     type: 'table',
-                                    sink_id: 'sink',
+                                    view_id: 'view',
                                     options: {
                                         '_jut_time_bounds': []
                                     }
                                 },
                                 {
                                     type: 'logger',
-                                    sink_id: 'sink',
+                                    view_id: 'view',
                                     options: {
                                         '_jut_time_bounds': []
                                     }
@@ -1213,22 +1213,22 @@ describe('Juttle Service Tests', function() {
                             expect(num_ticks).to.equal(2);
 
                             expect(num_marks).to.be.equal(6);
-                            expect(num_sink_ends).to.equal(2);
+                            expect(num_view_ends).to.equal(2);
                         } else if (data.type === 'tick') {
                             num_ticks++;
-                            expect(data.sink_id).to.match(/view\d+/);
+                            expect(data.view_id).to.match(/view\d+/);
                             expect(data.job_id).to.equal(job_id);
                         } else if (data.type === 'mark') {
                             num_marks++;
-                            expect(data.sink_id).to.match(/view\d+/);
+                            expect(data.view_id).to.match(/view\d+/);
                             expect(data.job_id).to.equal(job_id);
-                        } else if (data.type === 'sink_end') {
-                            num_sink_ends++;
-                            expect(data.sink_id).to.match(/view\d+/);
+                        } else if (data.type === 'view_end') {
+                            num_view_ends++;
+                            expect(data.view_id).to.match(/view\d+/);
                             expect(data.job_id).to.equal(job_id);
                         } else if (data.type === 'points') {
                             num_points++;
-                            expect(data.sink_id).to.match(/view\d+/);
+                            expect(data.view_id).to.match(/view\d+/);
                             expect(data.job_id).to.equal(job_id);
                             expect(data.points).to.have.length(1);
 


### PR DESCRIPTION
Fixes https://github.com/juttle/juttle-service/issues/37.

The failing tests are unrelated and are being fixed in https://github.com/juttle/juttle-service/pull/46.

@mstemm @demmer 

cc @mnibecker this changes the messages we send over the websocket to use `view` instead of `sink`.