### PR TITLE
update to juttle 0.5.0 and juttle-jsdp 0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ services:
 
 before_install:
     - export CXX="g++-4.8"
-    - npm install juttle@^0.4.0
 
 node_js:
     - '4.2'

--- a/bin/juttle
+++ b/bin/juttle
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+'use strict';
+
+//
+// Simple helper script to expose the juttle CLI as part of an
+// juttle-service installation.
+//
+let path = require('path');
+let juttle = path.resolve(__dirname, '../node_modules/juttle/bin/juttle');
+require(juttle)

--- a/lib/jsdp-value-converter.js
+++ b/lib/jsdp-value-converter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
+var JuttleMoment = require('juttle/lib/runtime/types').JuttleMoment;
 var moment = require('moment');
 var _ = require('underscore');
 

--- a/lib/juttle-service.js
+++ b/lib/juttle-service.js
@@ -3,7 +3,7 @@ var _ = require('underscore');
 var express = require('express');
 var logger = require('log4js').getLogger('juttle-service');
 var read_config = require('juttle/lib/config/read-config');
-var Juttle = require('juttle/lib/runtime').Juttle;
+var JuttleAdapters = require('juttle/lib/runtime/adapters');
 
 // Exposed handler for registering routes on an express app
 var addRoutes = require('./routes');
@@ -18,7 +18,7 @@ function configure(options) {
         options.config = config;
     }
 
-    Juttle.adapters.configure(options.config.adapters);
+    JuttleAdapters.configure(options.config.adapters);
 }
 
 // Simple wrapper class around a running instance of the service.

--- a/lib/juttle-service.js
+++ b/lib/juttle-service.js
@@ -4,6 +4,7 @@ var express = require('express');
 var logger = require('log4js').getLogger('juttle-service');
 var read_config = require('juttle/lib/config/read-config');
 var JuttleAdapters = require('juttle/lib/runtime/adapters');
+var getVersionInfo = require('./version');
 
 // Exposed handler for registering routes on an express app
 var addRoutes = require('./routes');
@@ -50,5 +51,6 @@ function run(options) {
 module.exports = {
     configure: configure,
     run: run,
+    getVersionInfo: getVersionInfo,
     addRoutes: addRoutes
 };

--- a/lib/juttle-subprocess.js
+++ b/lib/juttle-subprocess.js
@@ -41,7 +41,7 @@ var _ = require('underscore');
 var logger = JuttleLogger.getLogger('juttle-subprocess');
 
 var read_config = require('juttle/lib/config/read-config');
-var Juttle = require('juttle/lib/runtime').Juttle;
+var JuttleAdapters = require('juttle/lib/runtime/adapters');
 var JuttleErrors = require('juttle/lib/errors');
 
 // The only argument to this process is the path to the config
@@ -56,7 +56,7 @@ var JSDP = require('juttle-jsdp');
 var JSDPValueConverter = require('./jsdp-value-converter');
 
 var config = read_config({config_path: process.argv[2]});
-Juttle.adapters.configure(config.adapters);
+JuttleAdapters.configure(config.adapters);
 
 var running_program;
 

--- a/lib/juttle-subprocess.js
+++ b/lib/juttle-subprocess.js
@@ -110,7 +110,11 @@ process.on('message', function(msg) {
                 logger.error(msg, err);
                 send({
                     type: 'error',
-                    error: err
+                    error: {
+                        code: err.code,
+                        message: err.message,
+                        info: err.info
+                    }
                 });
             });
 
@@ -118,7 +122,11 @@ process.on('message', function(msg) {
                 logger.warn(msg, warn);
                 send({
                     type: 'warning',
-                    warning: warn
+                    warning: {
+                        code: warn.code,
+                        message: warn.message,
+                        info: warn.info
+                    }
                 });
             });
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -9,6 +9,7 @@ var jobs = require('./job-handlers');
 var paths = require('./path-handlers');
 var prepares = require('./prepare-handlers');
 var logger = require('log4js').getLogger('juttle-express-router');
+var getVersionInfo = require('./version');
 
 var JuttleServiceErrors = require('./errors');
 
@@ -99,6 +100,10 @@ function add_routes(app, options) {
     router.use(default_error_handler);
 
     app.use(API_PREFIX, router);
+
+    app.get('/version', (req, res) => {
+        res.send(getVersionInfo());
+    });
 
     // For the websocket routes, we need to add them directly to the
     // app, as the package we use (express-ws) doesn't support adding

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,0 +1,31 @@
+'use strict';
+
+let _ = require('underscore');
+let JuttleAdapters = require('juttle/lib/runtime/adapters');
+let juttleVersion = require('juttle/package.json').version;
+let juttleServiceVersion = require('../package.json').version;
+let juttleJSDPVersion = require('juttle-jsdp/package.json').version;
+
+const BUILT_IN_ADAPTERS = ['file', 'http', 'http_server', 'stdio', 'stochastic'];
+
+function getVersionInfo() {
+    let adapters = {};
+
+    // Filtering out builtin adapters based on the hard-coded list above
+    // and dynamically building the adapter module name are both
+    // temporary hacks until https://github.com/juttle/juttle/pull/472
+    // is released.
+    JuttleAdapters.list().filter((info) => {
+        return !_.contains(BUILT_IN_ADAPTERS, info.adapter);
+    }).forEach((info) => {
+        adapters[`juttle-${info.adapter}-adapter`] = info.version;
+    });
+
+    return _.extend({
+        'juttle-service': juttleServiceVersion,
+        'juttle': juttleVersion,
+        'juttle-jsdp': juttleJSDPVersion
+    }, adapters);
+}
+
+module.exports = getVersionInfo;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "express-ws": "^1.0.0-rc.2",
     "fs-extra": "^0.26.5",
     "juttle": "^0.5.1",
-    "juttle-jsdp": "^0.1.1",
+    "juttle-jsdp": "^0.3.0",
     "log4js": "^0.6.30",
     "minimist": "^1.2.0",
     "moment": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juttle-service",
-  "version": "0.2.1",
+  "version": "0.3.0-rc.0",
   "description": "API-based execution engine for juttle programs",
   "main": "index",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index",
   "bin": {
     "juttle-service": "bin/juttle-service",
-    "juttle-service-client": "bin/juttle-service-client"
+    "juttle-service-client": "bin/juttle-service-client",
+    "juttle": "bin/juttle"
   },
   "directories": {
     "doc": "docs",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "gulp-istanbul": "^0.10.3",
     "gulp-mocha": "^2.1.3",
     "isparta": "^4.0.0",
-    "mocha": "^2.4.5"
+    "mocha": "^2.4.5",
+    "sinon": "^1.17.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "express": "^4.13.4",
     "express-ws": "^1.0.0-rc.2",
     "fs-extra": "^0.26.5",
+    "juttle": "^0.5.1",
     "juttle-jsdp": "^0.1.1",
     "log4js": "^0.6.30",
     "minimist": "^1.2.0",
@@ -50,9 +51,6 @@
     "underscore": "^1.8.3",
     "uuid": "^2.0.1",
     "ws": "^0.4.31"
-  },
-  "peerDependencies": {
-    "juttle": "^0.4.0"
   },
   "devDependencies": {
     "bluebird-retry": "^0.5.3",

--- a/test/juttle-bin.spec.js
+++ b/test/juttle-bin.spec.js
@@ -1,0 +1,23 @@
+'use strict';
+let path = require('path');
+let expect = require('chai').expect;
+let child_process = require('child_process');
+
+let juttle_cmd = path.resolve(`${__dirname}/../bin/juttle`);
+
+describe('juttle bin', () => {
+    it('can run simple juttle', (done) => {
+        let child = child_process.spawn(juttle_cmd, ['-e', 'emit -limit 1 -from :0: | view text -format "json"']);
+
+        let output = '';
+        child.stdout.on('data', (data) => {
+            output += data;
+        });
+
+        child.on('close', (code) => {
+            expect(code).to.equal(0);
+            expect(JSON.parse(output)).to.deep.equal([{ time: '1970-01-01T00:00:00.000Z' }]);
+            done();
+        });
+    });
+});

--- a/test/juttle-service-client.spec.js
+++ b/test/juttle-service-client.spec.js
@@ -157,7 +157,7 @@ describe('juttle-service-client tests', function() {
         let opts = {path: 'has-syntax-error.juttle'};
         client.command(server, opts, 'run');
         return retry(function() {
-            expect(current_errors).to.contain('JUTTLE-SYNTAX-ERROR-WITH-EXPECTED');
+            expect(current_errors).to.contain('SYNTAX-ERROR-WITH-EXPECTED');
             expect(exit_status).to.equal(undefined);
         }, {interval: 100, max_tries: 10});
     });

--- a/test/juttle-service.spec.js
+++ b/test/juttle-service.spec.js
@@ -44,7 +44,7 @@ var has_syntax_error_info_obj = {
         program: 'emit -every :0.33s: -limit 5\n    | batch -every :1s:\n    | batch -every :1s:\n    | puty foo="bar"\n    | view table -display.progressive true\n'
     },
     err: {
-        code: 'JUTTLE-SYNTAX-ERROR-WITH-EXPECTED',
+        code: 'SYNTAX-ERROR-WITH-EXPECTED',
         info: {
             expected: [
                 {
@@ -332,7 +332,7 @@ describe('Juttle Service Tests', function() {
                             program: 'import \'no-such-juttle.juttle\' as nope;\n\nemit -limit 10 | put x=nope.a | view timechart;\n'
                         },
                         err: {
-                            code: 'RT-MODULE-NOT-FOUND',
+                            code: 'MODULE-NOT-FOUND',
                             info: {
                                 location: {
                                     'end': {
@@ -624,7 +624,7 @@ describe('Juttle Service Tests', function() {
                         bundle: bundle,
                         err: {
 
-                            code: 'JUTTLE-SYNTAX-ERROR-WITH-EXPECTED',
+                            code: 'SYNTAX-ERROR-WITH-EXPECTED',
                             info: {
                                 expected: [
                                     {
@@ -681,8 +681,7 @@ describe('Juttle Service Tests', function() {
                     info: {
                         bundle: bundle,
                         err: {
-
-                            code: 'JUTTLE-SYNTAX-ERROR-WITH-EXPECTED',
+                            code: 'SYNTAX-ERROR-WITH-EXPECTED',
                             info: {
                                 expected: [
                                     {
@@ -736,7 +735,7 @@ describe('Juttle Service Tests', function() {
                     info: {
                         bundle: bundle,
                         err: {
-                            code: 'RT-MODULE-NOT-FOUND',
+                            code: 'MODULE-NOT-FOUND',
                             info: {
                                 location: {
                                     end: {
@@ -966,7 +965,7 @@ describe('Juttle Service Tests', function() {
                 expect(response).to.have.status(200);
                 expect(response).to.have.json({
                     errors: [{
-                        code: 'RT-INTERNAL-ERROR',
+                        code: 'INTERNAL-ERROR',
                         info: {
                             error: 'Error: ENOENT: no such file or directory, open \'nobody\'',
                             location: {
@@ -974,7 +973,7 @@ describe('Juttle Service Tests', function() {
                                 filename: 'main',
                                 start: {column: 1, line: 1, offset: 0}
                             },
-                            procName: 'read'
+                            procName: 'read-file'
                         },
                         message: 'internal error Error: ENOENT: no such file or directory, open \'nobody\''
                     }],
@@ -1000,7 +999,7 @@ describe('Juttle Service Tests', function() {
                 expect(response).to.have.json({
                     errors: [],
                     warnings: [{
-                        code: 'RT-FIELD-NOT-FOUND',
+                        code: 'FIELD-NOT-FOUND',
                         info: {
                             field: 'nobody',
                             location: {
@@ -1790,7 +1789,7 @@ describe('Juttle Service Tests', function() {
                         bundle: bundle,
                         err: {
                             message: 'Cannot run a program without a flowgraph.',
-                            code: 'RT-PROGRAM-WITHOUT-FLOWGRAPH',
+                            code: 'PROGRAM-WITHOUT-FLOWGRAPH',
                             info: {
                                 location: {
                                     filename: 'main',
@@ -1823,7 +1822,7 @@ describe('Juttle Service Tests', function() {
                         bundle: bundle,
                         err: {
                             message: 'Expected ";", "|" or option but "j" found.',
-                            code: 'JUTTLE-SYNTAX-ERROR-WITH-EXPECTED',
+                            code: 'SYNTAX-ERROR-WITH-EXPECTED',
                             info: {
                                 location: {
                                     end: {

--- a/test/juttle-service.spec.js
+++ b/test/juttle-service.spec.js
@@ -795,7 +795,7 @@ describe('Juttle Service Tests', function() {
                     warnings: [],
                     output: {
                         view0: {
-                            data: [{type: 'points', points: [{foo: 'bar', 'time:date': '1970-01-01T00:00:00.000Z'}]}],
+                            data: [{type: 'points', points: [{foo: 'bar', 'time': '$date$1970-01-01T00:00:00.000Z'}]}],
                             options: {
                                 _jut_time_bounds: []
                             },
@@ -883,11 +883,11 @@ describe('Juttle Service Tests', function() {
                     warnings: [],
                     output: {
                         view0: {
-                            data: [{type: 'mark', 'time:date': '1970-01-01T00:00:00.000Z'},
-                                   {type: 'points', points: [{'time:date': '1970-01-01T00:00:00.000Z'}, {'time:date': '1970-01-01T00:00:01.000Z'}]},
-                                   {type: 'mark', 'time:date': '1970-01-01T00:00:02.000Z'},
-                                   {type: 'points', points: [{'time:date': '1970-01-01T00:00:02.000Z'}]},
-                                   {type: 'mark', 'time:date': '1970-01-01T00:00:04.000Z'}],
+                            data: [{type: 'mark', 'time': '$date$1970-01-01T00:00:00.000Z'},
+                                   {type: 'points', points: [{'time': '$date$1970-01-01T00:00:00.000Z'}, {'time': '$date$1970-01-01T00:00:01.000Z'}]},
+                                   {type: 'mark', 'time': '$date$1970-01-01T00:00:02.000Z'},
+                                   {type: 'points', points: [{'time': '$date$1970-01-01T00:00:02.000Z'}]},
+                                   {type: 'mark', 'time': '$date$1970-01-01T00:00:04.000Z'}],
                             options: {
                                 _jut_time_bounds: [],
                                 format: 'raw'
@@ -895,11 +895,11 @@ describe('Juttle Service Tests', function() {
                             type: 'text'
                         },
                         view1: {
-                            data: [{type: 'mark', 'time:date': '1970-01-01T00:00:00.000Z'},
-                                   {type: 'points', points: [{'time:date': '1970-01-01T00:00:00.000Z'}, {'time:date': '1970-01-01T00:00:01.000Z'}]},
-                                   {type: 'mark', 'time:date': '1970-01-01T00:00:02.000Z'},
-                                   {type: 'points', points: [{'time:date': '1970-01-01T00:00:02.000Z'}]},
-                                   {type: 'mark', 'time:date': '1970-01-01T00:00:04.000Z'}],
+                            data: [{type: 'mark', 'time': '$date$1970-01-01T00:00:00.000Z'},
+                                   {type: 'points', points: [{'time': '$date$1970-01-01T00:00:00.000Z'}, {'time': '$date$1970-01-01T00:00:01.000Z'}]},
+                                   {type: 'mark', 'time': '$date$1970-01-01T00:00:02.000Z'},
+                                   {type: 'points', points: [{'time': '$date$1970-01-01T00:00:02.000Z'}]},
+                                   {type: 'mark', 'time': '$date$1970-01-01T00:00:04.000Z'}],
                             options: {
                                 _jut_time_bounds: [],
                                 title: 'My Table'
@@ -920,7 +920,7 @@ describe('Juttle Service Tests', function() {
                     warnings: [],
                     output: {
                         view0: {
-                            data: [{type: 'points', points: [{foo: 'bar', 'time:date': '1970-01-01T00:00:00.000Z'}]}],
+                            data: [{type: 'points', points: [{foo: 'bar', 'time': '$date$1970-01-01T00:00:00.000Z'}]}],
                             options: {
                                 _jut_time_bounds: []
                             },
@@ -948,7 +948,7 @@ describe('Juttle Service Tests', function() {
                     warnings: [],
                     output: {
                         view0: {
-                            data: [{type: 'points', points: [{foo: 'baz', 'time:date': '1970-01-01T00:00:00.000Z'}]}],
+                            data: [{type: 'points', points: [{foo: 'baz', 'time': '$date$1970-01-01T00:00:00.000Z'}]}],
                             options: {
                                 _jut_time_bounds: []
                             },

--- a/test/juttle-service.spec.js
+++ b/test/juttle-service.spec.js
@@ -10,6 +10,8 @@ var Promise = require('bluebird');
 var findFreePort = Promise.promisify(require('find-free-port'));
 var fs = Promise.promisifyAll(require('fs'));
 var fs_extra = Promise.promisifyAll(require('fs-extra'));
+var JuttleAdapters = require('juttle/lib/runtime/adapters');
+var sinon = require('sinon');
 
 var JSDP = require('juttle-jsdp');
 var moment = require('moment');
@@ -1870,6 +1872,54 @@ describe('Juttle Service Tests', function() {
             var response = chakram.get(juttleBaseUrl + '/directory');
             expect(response).to.have.header('Access-Control-Allow-Origin', '*');
             return chakram.wait();
+        });
+    });
+
+    describe('version', function() {
+        let adapterListStub;
+        before(function() {
+            adapterListStub = sinon.stub(JuttleAdapters, 'list');
+            adapterListStub.returns([
+                {
+                    adapter: 'elastic',
+                    version: '0.4.0'
+                },
+                {
+                    adapter: 'file',
+                    version: '0.5.1'
+                }
+            ]);
+        });
+
+        after(function() {
+            adapterListStub.restore();
+        });
+
+        function verifyVersionInfo(versionInfo) {
+            let VERSION_REGEX = /[0-9]+\.[0-9]+\.[0-9]+/;
+            expect(versionInfo['juttle-elastic-adapter']).to.equal('0.4.0');
+            expect(versionInfo['juttle']).to.match(VERSION_REGEX);
+            expect(versionInfo['juttle-service']).to.match(VERSION_REGEX);
+            expect(versionInfo['juttle-jsdp']).to.match(VERSION_REGEX);
+            // built in adapters (file in this case) should not be listed
+            expect(versionInfo).to.have.keys([
+                'juttle-elastic-adapter',
+                'juttle',
+                'juttle-service',
+                'juttle-jsdp'
+            ]);
+        }
+
+        it('juttle-service.getVersionInfo', function() {
+            let versionInfo = service.getVersionInfo();
+            verifyVersionInfo(versionInfo);
+        });
+
+        it('/version endpoint', function() {
+            return chakram.get(juttleHostPort + '/version')
+                .then(function(response) {
+                    verifyVersionInfo(response.body);
+                });
         });
     });
 });


### PR DESCRIPTION
@mstemm @demmer @mnibecker 

Note:
- In https://github.com/juttle/juttle-service/commit/ccc97b212f8d785b3be00cf24572f8d31e4665c6, I switched to explicitly sending the `code`, `info`, and `message` because thats what the client wants. Error serialization was added to `juttle-jsdp`, and we can use it if we want, but from talking with @mnibecker  (and I agree) we don't want to have actual `Error` objects on the browser-side generated for these. Sending an `Error` object in and getting a plain object out also seems weird, so thats I'm sending `code`, `info`, `message` instead of the `Error`.