### PR TITLE
add bin/juttle which wraps node_modules/juttle/bin/juttle

### DIFF
--- a/bin/juttle
+++ b/bin/juttle
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+'use strict';
+
+//
+// Simple helper script to expose the juttle CLI as part of an
+// juttle-service installation.
+//
+let path = require('path');
+let juttle = path.resolve(__dirname, '../node_modules/juttle/bin/juttle');
+require(juttle)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index",
   "bin": {
     "juttle-service": "bin/juttle-service",
-    "juttle-service-client": "bin/juttle-service-client"
+    "juttle-service-client": "bin/juttle-service-client",
+    "juttle": "bin/juttle"
   },
   "directories": {
     "doc": "docs",

--- a/test/juttle-bin.spec.js
+++ b/test/juttle-bin.spec.js
@@ -1,0 +1,23 @@
+'use strict';
+let path = require('path');
+let expect = require('chai').expect;
+let child_process = require('child_process');
+
+let juttle_cmd = path.resolve(`${__dirname}/../bin/juttle`);
+
+describe('juttle bin', () => {
+    it('can run simple juttle', (done) => {
+        let child = child_process.spawn(juttle_cmd, ['-e', 'emit -limit 1 -from :0: | view text -format "json"']);
+
+        let output = '';
+        child.stdout.on('data', (data) => {
+            output += data;
+        });
+
+        child.on('close', (code) => {
+            expect(code).to.equal(0);
+            expect(JSON.parse(output)).to.deep.equal([{ time: '1970-01-01T00:00:00.000Z' }]);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
So you can use it from `juttle-service` and eventually `juttle-engine`.

@mstemm