### PR TITLE
expose version info as `/version` endpoint and in `juttle-service`

### DIFF
--- a/lib/juttle-service.js
+++ b/lib/juttle-service.js
@@ -4,6 +4,7 @@ var express = require('express');
 var logger = require('log4js').getLogger('juttle-service');
 var read_config = require('juttle/lib/config/read-config');
 var JuttleAdapters = require('juttle/lib/runtime/adapters');
+var getVersionInfo = require('./version');
 
 // Exposed handler for registering routes on an express app
 var addRoutes = require('./routes');
@@ -50,5 +51,6 @@ function run(options) {
 module.exports = {
     configure: configure,
     run: run,
+    getVersionInfo: getVersionInfo,
     addRoutes: addRoutes
 };

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -9,6 +9,7 @@ var jobs = require('./job-handlers');
 var paths = require('./path-handlers');
 var prepares = require('./prepare-handlers');
 var logger = require('log4js').getLogger('juttle-express-router');
+var getVersionInfo = require('./version');
 
 var JuttleServiceErrors = require('./errors');
 
@@ -99,6 +100,10 @@ function add_routes(app, options) {
     router.use(default_error_handler);
 
     app.use(API_PREFIX, router);
+
+    app.get('/version', (req, res) => {
+        res.send(getVersionInfo());
+    });
 
     // For the websocket routes, we need to add them directly to the
     // app, as the package we use (express-ws) doesn't support adding

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,0 +1,31 @@
+'use strict';
+
+let _ = require('underscore');
+let JuttleAdapters = require('juttle/lib/runtime/adapters');
+let juttleVersion = require('juttle/package.json').version;
+let juttleServiceVersion = require('../package.json').version;
+let juttleJSDPVersion = require('juttle-jsdp/package.json').version;
+
+const BUILT_IN_ADAPTERS = ['file', 'http', 'http_server', 'stdio', 'stochastic'];
+
+function getVersionInfo() {
+    let adapters = {};
+
+    // Filtering out builtin adapters based on the hard-coded list above
+    // and dynamically building the adapter module name are both
+    // temporary hacks until https://github.com/juttle/juttle/pull/472
+    // is released.
+    JuttleAdapters.list().filter((info) => {
+        return !_.contains(BUILT_IN_ADAPTERS, info.adapter);
+    }).forEach((info) => {
+        adapters[`juttle-${info.adapter}-adapter`] = info.version;
+    });
+
+    return _.extend({
+        'juttle-service': juttleServiceVersion,
+        'juttle': juttleVersion,
+        'juttle-jsdp': juttleJSDPVersion
+    }, adapters);
+}
+
+module.exports = getVersionInfo;

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "gulp-istanbul": "^0.10.3",
     "gulp-mocha": "^2.1.3",
     "isparta": "^4.0.0",
-    "mocha": "^2.4.5"
+    "mocha": "^2.4.5",
+    "sinon": "^1.17.3"
   }
 }

--- a/test/juttle-service.spec.js
+++ b/test/juttle-service.spec.js
@@ -10,6 +10,8 @@ var Promise = require('bluebird');
 var findFreePort = Promise.promisify(require('find-free-port'));
 var fs = Promise.promisifyAll(require('fs'));
 var fs_extra = Promise.promisifyAll(require('fs-extra'));
+var JuttleAdapters = require('juttle/lib/runtime/adapters');
+var sinon = require('sinon');
 
 var JSDP = require('juttle-jsdp');
 var moment = require('moment');
@@ -1870,6 +1872,54 @@ describe('Juttle Service Tests', function() {
             var response = chakram.get(juttleBaseUrl + '/directory');
             expect(response).to.have.header('Access-Control-Allow-Origin', '*');
             return chakram.wait();
+        });
+    });
+
+    describe('version', function() {
+        let adapterListStub;
+        before(function() {
+            adapterListStub = sinon.stub(JuttleAdapters, 'list');
+            adapterListStub.returns([
+                {
+                    adapter: 'elastic',
+                    version: '0.4.0'
+                },
+                {
+                    adapter: 'file',
+                    version: '0.5.1'
+                }
+            ]);
+        });
+
+        after(function() {
+            adapterListStub.restore();
+        });
+
+        function verifyVersionInfo(versionInfo) {
+            let VERSION_REGEX = /[0-9]+\.[0-9]+\.[0-9]+/;
+            expect(versionInfo['juttle-elastic-adapter']).to.equal('0.4.0');
+            expect(versionInfo['juttle']).to.match(VERSION_REGEX);
+            expect(versionInfo['juttle-service']).to.match(VERSION_REGEX);
+            expect(versionInfo['juttle-jsdp']).to.match(VERSION_REGEX);
+            // built in adapters (file in this case) should not be listed
+            expect(versionInfo).to.have.keys([
+                'juttle-elastic-adapter',
+                'juttle',
+                'juttle-service',
+                'juttle-jsdp'
+            ]);
+        }
+
+        it('juttle-service.getVersionInfo', function() {
+            let versionInfo = service.getVersionInfo();
+            verifyVersionInfo(versionInfo);
+        });
+
+        it('/version endpoint', function() {
+            return chakram.get(juttleHostPort + '/version')
+                .then(function(response) {
+                    verifyVersionInfo(response.body);
+                });
         });
     });
 });


### PR DESCRIPTION
@mstemm @demmer 

- Made `version.js` export a function instead of an object so any adapters registered after startup would be picked up (if we start supporting it).

Let me know if you guys have any feedback about this response format. Will add a test afterwards.

```
{
    "version": "0.2.1",
    "dependencies": {
        "juttle": "0.5.1",
        "juttle-jsdp": "0.3.0"
    },
    "adapters": [
        {
            "name": "elastic",
            "version": "0.5.0"
        },
        {
            "name": "postgres",
            "version": "(unknown)"
        },
        {
            "name": "file",
            "version": "0.5.1"
        },
        {
            "name": "http",
            "version": "0.5.1"
        },
        {
            "name": "stdio",
            "version": "0.5.1"
        },
        {
            "name": "stochastic",
            "version": "0.5.1"
        },
        {
            "name": "http_server",
            "version": "0.5.1"
        }
    ]
}
```