### PR TITLE
travis: don't run both 'npm test' and 'gulp test-coverage'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ node_js:
     - '5.0'
 
 script:
-    - npm test
     - gulp test-coverage
     - gulp lint
 


### PR DESCRIPTION
Tests are run as part of 'gulp test-coverage'.

@rlgomes @mstemm 