### PR TITLE
remove unnecessary setting of table default

### DIFF
--- a/lib/juttle-subprocess.js
+++ b/lib/juttle-subprocess.js
@@ -83,7 +83,7 @@ process.on('message', function(msg) {
 
         var compile_options = {
             stage: 'eval',
-            fg_processors: [implicit_views(config.implicit_view || 'table'), optimize, views_sourceinfo],
+            fg_processors: [implicit_views(config.implicit_view), optimize, views_sourceinfo],
             inputs: JSDPValueConverter.convertToJuttleValue(JSDP.deserialize(msg.inputs || {})),
             modules: msg.bundle.modules
         };

--- a/lib/prepare-handlers.js
+++ b/lib/prepare-handlers.js
@@ -20,7 +20,7 @@ function get_inputs(req, res, next) {
 
     var compile_options = {
         stage: 'flowgraph',
-        fg_processors: [implicit_views(config.implicit_view || 'table'), optimize],
+        fg_processors: [implicit_views(config.implicit_view), optimize],
         inputs: JSDPValueConverter.convertToJuttleValue(JSDP.deserialize(req.body.inputs || {})),
         modules: req.body.bundle.modules
     };


### PR DESCRIPTION
Caught this through code inspection but we're already setting the default for an implicit view to be `table`  [here](https://github.com/juttle/juttle/blob/master/lib/compiler/flowgraph/implicit_views.js#L9) so no need for this code.