### PR TITLE
add timestamp to each log

### DIFF
--- a/lib/juttle-subprocess.js
+++ b/lib/juttle-subprocess.js
@@ -14,6 +14,7 @@ JuttleLogger.getLogger = function(name) {
         send({
             type: 'log',
             name: name,
+            time: new Date().toISOString(),
             level: level,
             arguments: args
         });

--- a/test/juttle-service.spec.js
+++ b/test/juttle-service.spec.js
@@ -817,7 +817,7 @@ describe('Juttle Service Tests', function() {
                     expect(response.body.logs).to.have.length.gt(0);
                     _.each(response.body.logs, function(log) {
                         expect(log.type).to.equal('log');
-                        expect(log).to.include.keys('name', 'level', 'arguments');
+                        expect(log).to.include.keys('name', 'level', 'arguments', 'time');
                     });
                 })
                 .then(function() {


### PR DESCRIPTION
I believe this is the best place to add time to each log message. Log4j does this automatically for the logs it outputs but we need to add one manually so that juttle-viewer receives the right time.