### PR TITLE
Add a /config endpoint, revamp config management.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ usage: [--port <port>] [--root <path>]
        -h, --help:                            Print this help and exit
 ```
 
-``juttle-service`` uses log4js for logging and by default logs to ``log/juttle-service.log``.
+``juttle-service`` uses log4js for logging and by default logs to the console when in the foreground, ``/var/log/juttle-service.log`` when in the background.
 
 ### Juttle config file
 
@@ -58,16 +58,22 @@ The Juttle Service configuration options (default values shown):
         "compress_response": true,
 
         // Time (in ms) a finished job should wait for the first websocket
-        // to connect before disposing of the results.       
+        // to connect before disposing of the results.
         "delayed_job_cleanup": 10000,
 
         // The number messages job should buffer for sending to
         // websockets that join after the job has started.
-        "max_saved_messages": 1024
+        "max_saved_messages": 1024,
+
+        // After a job has finished, wait this many ms before closing the
+        // websocket connection associated with the job.
+        "delayed_endpoint_close": 10000
     },
     "adapters": { ... }
 }
 ```
+
+In addition, all command-line arguments other than `--config` can also be specified in ``juttle/config.json`` via their long arguments. When specified, command line arguments override any values found in the configuration file.
 
 ### Module resolution
 

--- a/bin/juttle-service
+++ b/bin/juttle-service
@@ -8,12 +8,6 @@ var daemonize = require('daemon');
 var service = require('..').service;
 var logSetup = require('..').logSetup;
 
-var defaults = {
-    'port': 2000,
-    'root': '/',
-    'log-level': 'info'
-};
-
 var possible_opts = {
     p: 'port',
     r: 'root',
@@ -34,7 +28,7 @@ function usage() {
     console.log('       -r, --root <path>:                     Use <path> as the root directory for juttle programs');
     console.log('       -c, --config <juttle-config-path>:     Read juttle config from <juttle-config-path>');
     console.log('       -d, --daemonize:                       Daemonize juttle-service and log to configured log file');
-    console.log('       -o, --output <logfile>:                Log to specififed file when daemonized');
+    console.log('       -o, --output <logfile>:                Log to specififed file instead of console');
     console.log('       -L, --log-config <log4js-config-path>: Configure logging from <log4js-config-path>. Overrides any value of -o');
     console.log('       -l, --log-level <level>:               Use a default log level of <level>. Overridden by any log level specified in -L');
     console.log('       -h, --help:                            Print this help and exit');
@@ -43,7 +37,10 @@ function usage() {
 
 var opts = minimist(process.argv.slice(2));
 
-_.defaults(opts, defaults);
+// All arguments to this program have associated switches.
+if (_.has(opts, '_')) {
+    usage();
+}
 
 // Expand any single-letter option to its full-length equalivent.
 _.each(possible_opts, function(opt, short) {
@@ -54,7 +51,6 @@ _.each(possible_opts, function(opt, short) {
 });
 
 var extra = _.difference(_.keys(opts), _.values(possible_opts));
-extra = _.without(extra, '_');
 
 if (opts.help) {
     usage();
@@ -65,18 +61,14 @@ if (extra.length > 0) {
     usage();
 }
 
-logSetup(_.defaults(opts, {'log-default-output': '/var/log/juttle-service.log'}));
+let config = service.configure(opts);
 
-if (opts.daemonize) {
+logSetup(config);
+
+if (config.daemonize) {
     daemonize();
 }
 
 require('log4js').getLogger('juttle-service').debug('initializing');
 
-var service_opts = {port: opts.port, root_directory: opts.root};
-
-if (_.has(opts, 'config')) {
-    service_opts.config_path = opts['config'];
-}
-
-service.run(service_opts);
+service.run(config, opts['config']);

--- a/docs/jobs-api.md
+++ b/docs/jobs-api.md
@@ -302,3 +302,21 @@ GET /api/v0/version-info HTTP/1.1
     "juttle-elastic-adapter": "0.5.0"
 }
 ```
+
+###GET /api/v0/config-info
+
+Returns the configuration for juttle-service.
+
+
+```
+GET /api/v0/config-info HTTP/1.1
+```
+
+```
+{
+    "port": 2000,
+    "root: "/home/ubuntu/juttles",
+    max_saved_messages: 1024
+...
+}
+```

--- a/lib/job-handlers.js
+++ b/lib/job-handlers.js
@@ -15,14 +15,14 @@ var job_mgr;
 var observer_mgr;
 var root_dir;
 
-function init(options) {
-    job_mgr = new JobManager({max_saved_messages: options.max_saved_messages,
-                              delayed_job_cleanup: options.delayed_job_cleanup,
-                              delayed_endpoint_close: options.delayed_endpoint_close,
-                              config_path: options.config_path});
+function init(config, config_path) {
+    job_mgr = new JobManager({max_saved_messages: config.max_saved_messages,
+                              delayed_job_cleanup: config.delayed_job_cleanup,
+                              delayed_endpoint_close: config.delayed_endpoint_close,
+                              config_path: config_path});
     observer_mgr = new ObserverManager({job_mgr: job_mgr});
 
-    root_dir = options.root_directory;
+    root_dir = config.root;
 }
 
 function create_job(req, res, next) {

--- a/lib/juttle-service.js
+++ b/lib/juttle-service.js
@@ -1,4 +1,5 @@
 'use strict';
+var path = require('path');
 var _ = require('underscore');
 var express = require('express');
 var logger = require('log4js').getLogger('juttle-service');
@@ -8,32 +9,69 @@ var JuttleAdapters = require('juttle/lib/runtime/adapters');
 // Exposed handler for registering routes on an express app
 var addRoutes = require('./routes');
 
-// Load the juttle configuration from either options.config_path or the
-// default juttle configuration locations.
-function configure(options) {
-    if (! _.has(options, 'config')) {
-        let config = read_config(options);
+const DEFAULT_CONFIG = {
+    port: 2000,
+    root: process.cwd(),
+    daemonize: false,
+    output: false,
+    'log-config': false,
+    'log-level': 'info',
+    'log-default-output': '/var/log/juttle-service.log',
+    max_saved_messages: 1024,
+    delayed_job_cleanup: 10000,
+    delayed_endpoint_close: 10000,
+    compress_response: true
+};
 
-        // Add the config as an option so addRoutes doesn't have to read it again.
-        options.config = config;
+// Starting with a default configuration for the service, update it
+// with any (command-line) options in options and any values from the
+// juttle config file (either at the location options.config or the
+// default location). Return the resulting configuration for the
+// juttle service.
+//
+// Additionally, call JuttleAdapters.configure() so this process has a
+// list of adapters it can return in /version-info.
+
+function configure(options) {
+
+    // Read juttle-config.{js,json} and add defaults for anything not
+    // specified.
+    let juttle_config = read_config({config_path: options.config});
+    JuttleAdapters.configure(juttle_config.adapters);
+
+    let config = {};
+
+    if (_.has(juttle_config, 'juttle-service')) {
+        config = juttle_config['juttle-service'];
     }
 
-    JuttleAdapters.configure(options.config.adapters);
+    _.defaults(config, DEFAULT_CONFIG);
+
+    // Also let any command-line arguments or directly provided
+    // configuration override defaults. The one exception to this is
+    // options['config'], which is actually the path to a config file
+    // to read, and not a configuration item itself. So that is
+    // ignored.
+
+    _.extend(config, _.omit(options, 'config'));
+
+    // Ensure the root is a full path
+    config.root = path.resolve(config.root);
+
+    return config;
 }
 
 // Simple wrapper class around a running instance of the service.
 class JuttleService {
-    constructor(options) {
-        configure(options);
-
+    constructor(config, config_path) {
         this._app = express();
 
         this._app.disable('x-powered-by');
 
-        addRoutes(this._app, options);
+        addRoutes(this._app, config, config_path);
 
-        this._server = this._app.listen(options.port, () => {
-            logger.info('Juttle service listening at http://localhost:' + options.port + ' with root directory:' + options.root_directory);
+        this._server = this._app.listen(config.port, () => {
+            logger.info('Juttle service listening at http://localhost:' + config.port + ' with root directory:' + config.root);
         });
     }
 
@@ -43,11 +81,12 @@ class JuttleService {
 }
 
 // Hook to run a new instance of the service
-function run(options) {
-    return new JuttleService(options);
+function run(config, config_path) {
+    return new JuttleService(config, config_path);
 }
 
 module.exports = {
+    default_config: DEFAULT_CONFIG,
     configure: configure,
     run: run,
     addRoutes: addRoutes

--- a/lib/log-setup.js
+++ b/lib/log-setup.js
@@ -4,13 +4,13 @@ var _ = require('underscore');
 var fs = require('fs-extra');
 var log4js = require('log4js');
 
-function logSetup(opts) {
-    opts = opts || {};
-    if (opts['log-config']) {
-        log4js.configure(opts['log-config']);
+function logSetup(config) {
+    config = config || {};
+    if (config['log-config']) {
+        log4js.configure(config['log-config']);
     } else {
         var levels = {
-            '[all]': opts['log-level'] || 'info'
+            '[all]': config['log-level'] || 'info'
         };
 
         // Handle node.js style debug configuration where DEBUG is a
@@ -30,17 +30,17 @@ function logSetup(opts) {
 
         // If daemonizing and if no output file was specified, use a
         // default.
-        if (opts.daemonize && !_.has(opts, 'output')) {
-            opts.output = opts['log-default-output'];
+        if (config.daemonize && ! config.output) {
+            config.output = config['log-default-output'];
         }
 
-        if (_.has(opts, 'output')) {
+        if (config.output) {
 
-            fs.ensureFileSync(opts.output);
-            fs.accessSync(opts.output, fs.R_OK | fs.W_OK);
+            fs.ensureFileSync(config.output);
+            fs.accessSync(config.output, fs.R_OK | fs.W_OK);
 
             log4js_opts.appenders = [
-                {type: 'file', filename: opts.output}
+                {type: 'file', filename: config.output}
             ];
 
         } else {

--- a/lib/path-handlers.js
+++ b/lib/path-handlers.js
@@ -9,8 +9,8 @@ var errors = require('./errors');
 
 var root_dir = '';
 
-function init(options) {
-    root_dir = options.root_directory;
+function init(config) {
+    root_dir = config.root;
 }
 
 function get_path(req, res, next) {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,5 +1,4 @@
 'use strict';
-var _ = require('underscore');
 var express = require('express');
 var expressWs = require('express-ws');
 var bodyParser = require('body-parser');
@@ -35,43 +34,16 @@ function default_error_handler(err, req, res, next) {
     res.status(err.status()).send(err);
 }
 
-function add_routes(app, options) {
+function add_routes(app, config, config_path) {
 
-    let max_saved_messages = 1024;
-    let delayed_job_cleanup = 10000;
-    let delayed_endpoint_close = options.delayed_endpoint_close || 10000;
-    let compress_response = true;
-
-    if (_.has(options.config, 'juttle-service')) {
-        if (_.has(options.config['juttle-service'], 'max_saved_messages')) {
-            max_saved_messages = options.config['juttle-service'].max_saved_messages;
-        }
-
-        if (_.has(options.config['juttle-service'], 'delayed_job_cleanup')) {
-            delayed_job_cleanup = options.config['juttle-service'].delayed_job_cleanup;
-        }
-
-        if (_.has(options.config['juttle-service'], 'delayed_endpoint_close')) {
-            delayed_endpoint_close = options.config['juttle-service'].delayed_endpoint_close;
-        }
-
-        if (_.has(options.config['juttle-service'], 'compress_response')) {
-            compress_response = options.config['juttle-service'].compress_response;
-        }
-    }
-
-    jobs.init({max_saved_messages: max_saved_messages,
-               delayed_job_cleanup: delayed_job_cleanup,
-               delayed_endpoint_close: delayed_endpoint_close,
-               config_path: options.config_path,
-               root_directory: options.root_directory});
-    paths.init({root_directory: options.root_directory});
+    jobs.init(config, config_path);
+    paths.init(config);
 
     // Create an express router to handle all the non-websocket
     // routes.
     let router = express.Router();
 
-    if (compress_response) {
+    if (config.compress_response) {
         router.use(compression());
     }
 
@@ -101,11 +73,13 @@ function add_routes(app, options) {
         res.send(getVersionInfo());
     });
 
+    router.get('/config-info', (req, res) => {
+        res.send(config);
+    });
+
     router.use(default_error_handler);
 
     app.use(API_PREFIX, router);
-
-
 
     // For the websocket routes, we need to add them directly to the
     // app, as the package we use (express-ws) doesn't support adding

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var _ = require('underscore');
+var expect = require('chai').expect;
+var chakram = require('chakram');
+var ckexpect = chakram.expect;
+var Promise = require('bluebird');
+var findFreePort = Promise.promisify(require('find-free-port'));
+
+// Test verifying the proper overrides of command-line options,
+// juttle-config file, and built-in defaults.
+var service = require('..').service;
+
+describe('Juttle Service Configuration', function() {
+
+    let svc = undefined;
+    let config_override_path = `${__dirname}/test-configs/override-defaults.json`;
+
+    after(function() {
+        if (svc) {
+            svc.stop();
+        }
+    });
+
+    it('Returns built-in defaults', function() {
+        let config = service.configure({});
+        expect(config).to.deep.equal(service.default_config);
+    });
+
+    it('Fully normalizes a path "."', function() {
+        let config = service.configure({root: '.'});
+        expect(config).to.deep.equal(_.extend({}, service.default_config, {root: process.cwd()}));
+    });
+
+    it('is overridden by values in juttle-config.json', function() {
+        let config = service.configure({config: config_override_path});
+        expect(config).to.deep.equal(_.extend({}, service.default_config, {port: 9183, output: 'my-log.txt'}));
+    });
+
+    it('is overridden by values provided directly', function() {
+        let config = service.configure({config: config_override_path, port: 9184, 'log-level': 'debug'});
+        expect(config).to.deep.equal(_.extend({}, service.default_config, {port: 9184, output: 'my-log.txt', 'log-level': 'debug'}));
+    });
+
+    it('can be read via GET /config-info', function() {
+        return findFreePort(10000, 20000)
+        .then((freePort) => {
+            let config = service.configure({config: config_override_path, port: freePort, 'log-level': 'debug'});
+            svc = service.run(config);
+
+            let response = chakram.get(`http://localhost:${freePort}/api/v0/config-info`);
+            ckexpect(response).to.have.status(200);
+            let exp = _.extend({}, service.default_config, {port: freePort, output: 'my-log.txt', 'log-level': 'debug'});
+            ckexpect(response).to.have.json(exp);
+            return chakram.wait();
+        });
+    });
+});

--- a/test/juttle-service-bin.spec.js
+++ b/test/juttle-service-bin.spec.js
@@ -18,7 +18,7 @@ describe('juttle-service-client binary', function() {
         findFreePort(10000, 20000)
         .then((freePort) => {
             server = 'localhost:' + freePort;
-            juttle_service = service.run({port: freePort, root_directory: __dirname});
+            juttle_service = service.run({port: freePort, root: __dirname});
         });
     });
 

--- a/test/juttle-service-client.spec.js
+++ b/test/juttle-service-client.spec.js
@@ -39,7 +39,7 @@ describe('juttle-service-client tests', function() {
         findFreePort(10000, 20000)
         .then((freePort) => {
             server = 'localhost:' + freePort;
-            juttle_service = service.run({port: freePort, root_directory: juttleRoot, delayed_endpoint_close: 2000});
+            juttle_service = service.run({port: freePort, root: juttleRoot, delayed_endpoint_close: 2000});
         });
     });
 
@@ -90,13 +90,16 @@ describe('juttle-service-client tests', function() {
         done();
     });
 
+    const RETRY_INTERVAL = 200;
+    const MAX_RETRIES = 50;
+
     it('Can call list_jobs for all jobs', function() {
         let opts = {};
         client.command(server, opts, 'list_jobs');
         return retry(function() {
             expect(current_output).to.contain('[]');
             expect(exit_status).to.equal(undefined);
-        }, {interval: 100, max_tries: 10});
+        }, {interval: RETRY_INTERVAL, max_tries: MAX_RETRIES});
     });
 
     it('Can call list_observers for all observers', function() {
@@ -105,7 +108,7 @@ describe('juttle-service-client tests', function() {
         return retry(function() {
             expect(current_output).to.contain('[]');
             expect(exit_status).to.equal(undefined);
-        }, {interval: 100, max_tries: 10});
+        }, {interval: RETRY_INTERVAL, max_tries: MAX_RETRIES});
     });
 
     it('Can call subscribe for an observer id', function() {
@@ -114,7 +117,7 @@ describe('juttle-service-client tests', function() {
         return retry(function() {
             expect(current_output).to.contain('Subscribing to all jobs associated with observer');
             expect(exit_status).to.equal(undefined);
-        }, {interval: 100, max_tries: 10});
+        }, {interval: RETRY_INTERVAL, max_tries: MAX_RETRIES});
     });
 
     it('Can call subscribe for a job id', function() {
@@ -123,7 +126,7 @@ describe('juttle-service-client tests', function() {
         return retry(function() {
             expect(current_output).to.contain('Web socket connection closed, exiting');
             expect(exit_status).to.equal(0);
-        }, {interval: 100, max_tries: 10});
+        }, {interval: RETRY_INTERVAL, max_tries: MAX_RETRIES});
     });
 
     it('Can delete a job', function() {
@@ -132,7 +135,7 @@ describe('juttle-service-client tests', function() {
         return retry(function() {
             expect(current_errors).to.contain('No such job: myjob');
             expect(exit_status).to.equal(undefined);
-        }, {interval: 100, max_tries: 10});
+        }, {interval: RETRY_INTERVAL, max_tries: MAX_RETRIES});
     });
 
     it('Can run a job', function() {
@@ -141,7 +144,7 @@ describe('juttle-service-client tests', function() {
         return retry(function() {
             expect(current_output).to.contain('Started job: {"job_id":');
             expect(exit_status).to.equal(undefined);
-        }, {interval: 100, max_tries: 10});
+        }, {interval: RETRY_INTERVAL, max_tries: MAX_RETRIES});
     });
 
     it('Can run a job with --wait', function() {
@@ -150,7 +153,7 @@ describe('juttle-service-client tests', function() {
         return retry(function() {
             expect(current_output).to.contain('Starting program and waiting for it to finish');
             expect(exit_status).to.equal(undefined);
-        }, {interval: 100, max_tries: 10});
+        }, {interval: RETRY_INTERVAL, max_tries: MAX_RETRIES});
     });
 
     it('Can run a job with syntax errors and get errors back', function() {
@@ -159,7 +162,7 @@ describe('juttle-service-client tests', function() {
         return retry(function() {
             expect(current_errors).to.contain('SYNTAX-ERROR-WITH-EXPECTED');
             expect(exit_status).to.equal(undefined);
-        }, {interval: 100, max_tries: 10});
+        }, {interval: RETRY_INTERVAL, max_tries: MAX_RETRIES});
     });
 
     it('Can get_inputs', function() {
@@ -168,7 +171,7 @@ describe('juttle-service-client tests', function() {
         return retry(function() {
             expect(current_output).to.contain('"value": "my"');
             expect(exit_status).to.equal(undefined);
-        }, {interval: 100, max_tries: 10});
+        }, {interval: RETRY_INTERVAL, max_tries: MAX_RETRIES});
     });
 
     it('Can get_inputs with errors', function() {
@@ -177,7 +180,7 @@ describe('juttle-service-client tests', function() {
         return retry(function() {
             expect(current_errors).to.contain('invalid input inval');
             expect(exit_status).to.equal(1);
-        }, {interval: 100, max_tries: 10});
+        }, {interval: RETRY_INTERVAL, max_tries: MAX_RETRIES});
     });
 
     it('Can call custom provided command', function() {
@@ -187,7 +190,7 @@ describe('juttle-service-client tests', function() {
             expect(mycmd_called).to.equal(true);
             expect(myarg_value).to.equal('foo');
             expect(exit_status).to.equal(undefined);
-        }, {interval: 100, max_tries: 10});
+        }, {interval: RETRY_INTERVAL, max_tries: MAX_RETRIES});
     });
 
     it('Get Usage for unrecognized command', function() {
@@ -195,7 +198,7 @@ describe('juttle-service-client tests', function() {
         return retry(function() {
             expect(current_output).to.contain('usage: ');
             expect(exit_status).to.equal(1);
-        }, {interval: 100, max_tries: 10});
+        }, {interval: RETRY_INTERVAL, max_tries: MAX_RETRIES});
     });
 
 

--- a/test/juttle-service.spec.js
+++ b/test/juttle-service.spec.js
@@ -103,15 +103,11 @@ describe('Juttle Service Tests', function() {
             // just so we get increased code coverage in routes.js
             juttle_service = service.run({
                 port: freePort,
-                root_directory: juttleRoot,
-                config: {
-                    'juttle-service': {
-                        delayed_endpoint_close: 2000,
-                        max_saved_messages: 1000,
-                        delayed_job_cleanup: 10000,
-                        compress_response: false
-                    }
-                }
+                root: juttleRoot,
+                delayed_endpoint_close: 2000,
+                max_saved_messages: 1000,
+                delayed_job_cleanup: 10000,
+                compress_response: false
             });
         });
     });

--- a/test/test-configs/override-defaults.json
+++ b/test/test-configs/override-defaults.json
@@ -1,0 +1,6 @@
+{
+    "juttle-service": {
+        "port": 9183,
+        "output": "my-log.txt"
+    }
+}


### PR DESCRIPTION
Add a /config endpoint that returns the configuration of the
juttle-service. To manage this correctly, this led to a bunch of other
changes that rearranged how config was stored and how it can be
overridden.

The config is now created in
juttle-service.js:configure. Configuration is applied in the following
precedence order:

 - the const DEFAULT_CONFIG
 - .juttle-config.json (obtained from read_config()) under the "juttle-service" property
 - configuration provided directly, either directly for unit tests or
   via command line args in the juttle-service binary.

We still have to pass the config file path around so it can be used
when invoking the juttle subprocess. Pass this explicitly instead of
in a general options object. Generally, be more consistent about using
the variable config to hold config and opts to hold command line
arguments.

Add the new endpoint to the the jobs api doc.

Add unit tests that test both the precedence of the overrides as well
as fetching the /config endpoint to fetch the config.

Update a few unit tests that were passing direct config as items below
a config: juttle-service: property to just provide them directly.

I also was running across a few failures with the
juttle-service-client tests timing out. The default wait time of 1
second was a bit too aggressive, as I was seeing tests taking ~600 on
average. Increased the timeout up to 5 seconds.

Update the README to reflect this precedence. Also fix some out of
date items (wrong log path, missing delayed_endpoint_close).

@demmer @go-oleg @VladVega 