### PR TITLE
Resolve relative paths for root_directory

### DIFF
--- a/bin/juttle-service
+++ b/bin/juttle-service
@@ -3,6 +3,7 @@
 
 /* eslint no-console: 0 */
 var _ = require('underscore');
+var path = require('path');
 var minimist = require('minimist');
 var daemonize = require('daemon');
 var service = require('..').service;
@@ -73,7 +74,7 @@ if (opts.daemonize) {
 
 require('log4js').getLogger('juttle-service').debug('initializing');
 
-var service_opts = {port: opts.port, root_directory: opts.root};
+var service_opts = {port: opts.port, root_directory: path.resolve(opts.root)};
 
 if (_.has(opts, 'config')) {
     service_opts.config_path = opts['config'];

--- a/lib/juttle-service.js
+++ b/lib/juttle-service.js
@@ -1,4 +1,5 @@
 'use strict';
+var path = require('path');
 var _ = require('underscore');
 var express = require('express');
 var logger = require('log4js').getLogger('juttle-service');
@@ -25,6 +26,14 @@ function configure(options) {
 class JuttleService {
     constructor(options) {
         configure(options);
+
+        if (!options.root_directory) {
+            throw new Error('must provide option root_directory');
+        }
+
+        if (!path.isAbsolute(options.root_directory)) {
+            throw new Error('root_directory path must be absolute');
+        }
 
         this._app = express();
 


### PR DESCRIPTION
For ./bin/juttle-service, resolve relative paths for --root option.

Also, in juttle-service constructor, throw error if root_directory
option is not provided or if root_directory is not an absolute path.

Closes juttle/juttle-engine#69