### PR TITLE
pulling in juttle@0.6.0

### DIFF
--- a/lib/juttle-subprocess.js
+++ b/lib/juttle-subprocess.js
@@ -49,9 +49,6 @@ var JuttleErrors = require('juttle/lib/errors');
 // file. May not be provided, in which case a default set of search
 // paths will be used.
 var compiler = require('juttle/lib/compiler');
-var optimize = require('juttle/lib/compiler/optimize');
-var views_sourceinfo = require('juttle/lib/compiler/flowgraph/views_sourceinfo');
-var implicit_views = require('juttle/lib/compiler/flowgraph/implicit_views');
 
 var JSDP = require('juttle-jsdp');
 var JSDPValueConverter = require('./jsdp-value-converter');
@@ -84,7 +81,7 @@ process.on('message', function(msg) {
 
         var compile_options = {
             stage: 'eval',
-            fg_processors: [implicit_views(config.implicit_view), optimize, views_sourceinfo],
+            implicit_view: config.implicit_view,
             inputs: JSDPValueConverter.convertToJuttleValue(JSDP.deserialize(msg.inputs || {})),
             modules: msg.bundle.modules
         };

--- a/lib/prepare-handlers.js
+++ b/lib/prepare-handlers.js
@@ -6,8 +6,6 @@ var logger = require('log4js').getLogger('prepare-handlers');
 var read_config = require('juttle/lib/config/read-config');
 var config = read_config();
 var compiler = require('juttle/lib/compiler');
-var optimize = require('juttle/lib/compiler/optimize');
-var implicit_views = require('juttle/lib/compiler/flowgraph/implicit_views');
 var JuttleServiceErrors = require('./errors');
 var JuttleErrors = require('juttle/lib/errors');
 
@@ -20,7 +18,7 @@ function get_inputs(req, res, next) {
 
     var compile_options = {
         stage: 'flowgraph',
-        fg_processors: [implicit_views(config.implicit_view), optimize],
+        implicit_view: config.implicit_view,
         inputs: JSDPValueConverter.convertToJuttleValue(JSDP.deserialize(req.body.inputs || {})),
         modules: req.body.bundle.modules
     };

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "express": "^4.13.4",
     "express-ws": "^1.0.0-rc.2",
     "fs-extra": "^0.26.5",
-    "juttle": "^0.5.1",
+    "juttle": "^0.6.0",
     "juttle-jsdp": "^0.3.0",
     "log4js": "^0.6.30",
     "minimist": "^1.2.0",


### PR DESCRIPTION
this takes advantage of the latest changes in juttle 0.6.0 to not
specify the flowgraph processors which now have defaults that include
the runaway program detector