### PR TITLE
bump up the default delayed_endpoint_close timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ The Juttle Service configuration options (default values shown):
         "max_saved_messages": 1024,
 
         // After a job has finished, wait this many ms before closing the
-        // websocket connection associated with the job.
-        "delayed_endpoint_close": 10000
+        // websocket connection associated with the job. A well behaved
+        // client should close the socket before this time, but we close it
+        // server-side to avoid leaking sockets.
+        "delayed_endpoint_close": 600000
     },
     "adapters": { ... }
 }

--- a/lib/juttle-service.js
+++ b/lib/juttle-service.js
@@ -19,7 +19,7 @@ const DEFAULT_CONFIG = {
     'log-default-output': '/var/log/juttle-service.log',
     max_saved_messages: 1024,
     delayed_job_cleanup: 10000,
-    delayed_endpoint_close: 10000,
+    delayed_endpoint_close: 600000,
     compress_response: true
 };
 


### PR DESCRIPTION
Now that juttle-client-library closes the websocket after getting the
job_end indication, bump up the default value for delayed_endpoint_close
to 10 minutes to reduce the risk of prematurely closing the socket before
all the data can be pushed over the wire.

Fixes #72 

@mstemm @go-oleg