### PR TITLE
juttle-subprocess: send 'now' value in program_started message

### DIFF
--- a/docs/jsdp-api.md
+++ b/docs/jsdp-api.md
@@ -72,7 +72,11 @@ Sent when a new program is executed.
       options {
           ...
       }
-  }]
+  }],
+  juttleEnv: {
+      // The value of :now: used in program execution.
+      now: "2015-11-14T02:39:48.833Z"
+  }
 }
 ```
 

--- a/lib/juttle-job.js
+++ b/lib/juttle-job.js
@@ -136,7 +136,8 @@ class JuttleJob {
                         self._received_program_started = true;
                         self._on_job_msg({type: 'job_start',
                                               job_id: self._job_id,
-                                              views: msg.views});
+                                              views: msg.views,
+                                              juttleEnv: msg.juttleEnv});
                         resolve({job_id: self._job_id, pid: self._child.pid});
                         break;
                     case 'juttle_error':

--- a/lib/juttle-subprocess.js
+++ b/lib/juttle-subprocess.js
@@ -102,7 +102,10 @@ process.on('message', function(msg) {
 
             send({
                 type: 'program_started',
-                views: view_descs
+                views: view_descs,
+                juttleEnv: {
+                    now: program.env.now
+                }
             });
 
             // Start listening for callbacks from the interpreter for

--- a/test/juttle-service.spec.js
+++ b/test/juttle-service.spec.js
@@ -1216,6 +1216,8 @@ describe('Juttle Service Tests', function() {
                         data.views[0].view_id = 'view';
                         data.views[1].view_id = 'view';
 
+                        expect(data.juttleEnv.now).to.be.instanceOf(Date);
+
                         expect(data.views).to.deep.equal([
                             {
                                 type: 'table',

--- a/test/juttle-subprocess.spec.js
+++ b/test/juttle-subprocess.spec.js
@@ -89,6 +89,26 @@ describe('juttle-subprocess', function() {
         });
     });
 
+    it('program_started contains juttleEnv with "now" value', function() {
+        process.emit('message', {
+            cmd: 'run',
+            bundle: {
+                program: 'emit -limit 1 | put now = :now: | view table'
+            }
+        });
+
+        return waitForMessage({ type: 'done' })
+        .then(function() {
+            var programStartedMessage = findMessage({ type: 'program_started' });
+            var juttleEnv = JSDP.deserialize(programStartedMessage).juttleEnv;
+            var message = findMessage({ type: 'data' });
+            var points = JSDP.deserialize(message.data.points);
+            // Verify that the now value in juttleEnv is truly `now`
+            // by comparing against the now field created in the juttle above.
+            expect(points[0].now.getTime()).to.equal(juttleEnv.now.getTime());
+        });
+    });
+
     it('can emit compile erro correctly ', function() {
         process.emit('message', {
             cmd: 'run',


### PR DESCRIPTION
Resolves https://github.com/juttle/juttle-service/issues/50

Reasons for adding this:
- views need to know what value of :now: a program was run with to compute the bounds of '-last' in _jut_time_bounds.
- This information may be generally useful to display in a client so a user knows time of the query they are currently viewing.

@mstemm @demmer 

If you guys prefer `juttleEnv` to be underscored, let me know

EDIT: Should just call it `env` and call it a day.