### PR TITLE
Fix juttle-service so it can run with no options.

### DIFF
--- a/bin/juttle-service
+++ b/bin/juttle-service
@@ -38,9 +38,12 @@ function usage() {
 var opts = minimist(process.argv.slice(2));
 
 // All arguments to this program have associated switches.
-if (_.has(opts, '_')) {
+if (_.has(opts, '_') && opts['_'].length !== 0) {
     usage();
 }
+
+// Take '_' out now, we don't need it any longer.
+opts = _.omit(opts, '_');
 
 // Expand any single-letter option to its full-length equalivent.
 _.each(possible_opts, function(opt, short) {

--- a/test/juttle-service-bin.spec.js
+++ b/test/juttle-service-bin.spec.js
@@ -27,13 +27,10 @@ describe('juttle-service-client binary', function() {
     });
 
     it('can be run with --help', function() {
-        try {
-            child_process.spawnSync(juttle_service_client_cmd, ['--help']);
-        } catch (err) {
-            // The status is 1, but we can also check the output for 'usage:'
-            expect(err.status).to.equal(1);
-            expect(err.stdout.toString()).to.match(/^usage: /);
-        }
+        var ret = child_process.spawnSync(juttle_service_client_cmd, ['--help']);
+        // The status is 1, but we can also check the output for 'usage:'
+        expect(ret.status).to.equal(1);
+        expect(ret.stdout.toString()).to.match(/^usage: /);
     });
 
     it('can be run with list_jobs', function(done) {
@@ -63,25 +60,32 @@ describe('juttle-service-client binary', function() {
 describe('juttle-service binary', function() {
 
     it('can be run with --help', function() {
-        try {
-            child_process.spawn(juttle_service_cmd, ['--help']);
-        } catch (err) {
-            // The status is 1, but we can also check the output for 'usage:'
-            expect(err.status).to.equal(1);
-            expect(err.stdout.toString()).to.match(/^usage: /);
-        }
+        var ret = child_process.spawnSync(juttle_service_cmd, ['--help']);
+        // The status is 1, but we can also check the output for 'usage:'
+        expect(ret.status).to.equal(1);
+        expect(ret.stdout.toString()).to.match(/^usage: /);
+    });
+
+    it('Returns usage() when run with non-option arguments', function() {
+        var ret = child_process.spawnSync(juttle_service_cmd, ['foo']);
+        // The status is 1, but we can also check the output for 'usage:'
+        expect(ret.status).to.equal(1);
+        expect(ret.stdout.toString()).to.match(/^usage: /);
     });
 
     it('can be run and can see startup line', function(done) {
+        var got_output = false;
         findFreePort(10000, 20000)
         .then((freePort) => {
             let child = child_process.spawn(juttle_service_cmd, ['--port', freePort]);
             child.stdout.on('data', (data) => {
                 if (data.toString().match(/Juttle service listening at/)) {
+                    got_output = true;
                     child.kill('SIGKILL');
                 }
             });
             child.on('close', (code) => {
+                expect(got_output).to.equal(true);
                 done();
             });
             child.on('error', (msg) => {


### PR DESCRIPTION
https://github.com/juttle/juttle-service/pull/67/files introduced a
regression where juttle-service could not be run at all. Testing for _
in options is not a good indicator of whether there are non-option
arguments. You must also check to see whether the array is empty or
not.

Additionally, the unit tests that would have caught this also had
bugs:

 - child_process.spawn does not throw an error when the process exits
   with non-zero, so the catch {} block wasn't actually being
   invoked. Switch to using spawnSync and checking the result.

 - For the test that did specify a port, you must also positively
   check that you saw the startup line, and not simply assume that if
   it exits the test succeeds.